### PR TITLE
Convert diffxpy to optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         "click",
         "ujson",
         "xxhash",
-        "diffxpy",
     ],
+    extras_require={"stats": ["diffxpy", ]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="capcruncher",
-    version="0.1.0a1",
+    version="0.1.0a2",
     author="Alastair Smith",
     author_email="alastair.smith@ndcls.ox.ac.uk",
     packages=find_packages(),


### PR DESCRIPTION
Diffxpy is not currently on conda. Adding this as an optional dependency should allow this to build correctly.