### PR TITLE
Correct issues problems in the pipeline for Tiled-C

### DIFF
--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -108,6 +108,9 @@ for key in P.PARAMS:
 ######################
 
 
+# Method of analysis
+ANALYSIS_METHOD = P.PARAMS.get('analysis_method', 'capture')
+
 # Determines the number of samples being processed
 N_SAMPLES = len(
     {re.match(r"(.*)_R*[12].fastq.*", fn).group(1) for fn in glob.glob("*.fastq*")}

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1589,7 +1589,7 @@ def pipeline_make_report(infile, outfile):
 # Reporter pileups  #
 #####################
 
-
+@active_if(ANALYSIS_METHOD == 'capture' or ANALYSIS_METHOD == 'tri')
 @follows(mkdir("capcruncher_analysis/bedgraphs"))
 @transform(
     reporters_store_merged,
@@ -1612,7 +1612,7 @@ def reporters_make_bedgraph(infile, outfile, sample_name):
 
     touch_file(outfile)
 
-
+@active_if(ANALYSIS_METHOD == 'capture' or ANALYSIS_METHOD == 'tri')
 @transform(
     reporters_store_merged,
     regex(r".*/(.*).hdf5"),
@@ -1650,6 +1650,7 @@ def reporters_make_bedgraph_normalised(infile, outfile, sample_name):
 
 
 @active_if(N_SAMPLES >= 2)
+@active_if(ANALYSIS_METHOD == 'capture' or ANALYSIS_METHOD == 'tri')
 @follows(
     mkdir("capcruncher_compare/bedgraphs_union"),
     reporters_make_bedgraph,
@@ -1695,6 +1696,7 @@ def reporters_make_union_bedgraph(infiles, outfile, normalisation_type, capture_
 
 
 @active_if(N_SAMPLES >= 2)
+@active_if(ANALYSIS_METHOD == 'capture' or ANALYSIS_METHOD == 'tri')
 @follows(
     mkdir("capcruncher_compare/bedgraphs_comparison/"), reporters_make_union_bedgraph
 )
@@ -1772,6 +1774,7 @@ def reporters_make_comparison_bedgraph(infile, outfile, viewpoint):
     touch_file(outfile)
 
 
+@active_if(ANALYSIS_METHOD == 'capture' or ANALYSIS_METHOD == 'tri')
 @follows(
     mkdir("capcruncher_analysis/bigwigs"),
     reporters_make_bedgraph,
@@ -1825,7 +1828,7 @@ def viewpoints_to_bigbed(infile, outfile):
     )
 
 
-@active_if(HUB)
+@active_if(HUB and (ANALYSIS_METHOD == 'capture' or ANALYSIS_METHOD == "tri"))
 @merge(
     [reporters_make_bigwig, viewpoints_to_bigbed, pipeline_make_report],
     os.path.join(


### PR DESCRIPTION
Due to a previous re-write, bigWig related tasks are still active for Tiled-C. This should not be the case.