### PR TITLE
Correct reporter statistics

### DIFF
--- a/capcruncher/cli/alignments_filter.py
+++ b/capcruncher/cli/alignments_filter.py
@@ -118,6 +118,10 @@ def filter(
      sample_name (str, optional): Sample being processed e.g. DOX-treated_1. Defaults to "".
      read_type (str, optional): Process combined(flashed) or non-combined reads (pe) used for statistics. Defaults to "".
      gzip (bool, optional): Compress output with gzip. Defaults to False.
+     fragments (bool, optional): Enables fragments to be output. Defaults to True.
+     read_stats (bool, optional): Enables read level statistics to be output. Defaults to True.
+     slice_stats (bool, optional): Enables slice level statistics to be output. Defaults to True.
+     cis_and_trans_stats (bool, optional): Enables cis/trans statistics to be output. Defaults to True.
     """
 
     # Read bam file and merege annotations

--- a/capcruncher/cli/alignments_filter.py
+++ b/capcruncher/cli/alignments_filter.py
@@ -65,6 +65,11 @@ def filter(
     sample_name: str = "",
     read_type: str = "",
     gzip: bool = False,
+    output_fragments: bool = True,
+    output_read_stats: bool = True,
+    output_slice_stats: bool = True,
+    output_cis_and_trans_stats: bool = True,
+
 ):
     """
     Removes unwanted aligned slices and identifies reporters.

--- a/capcruncher/cli/alignments_filter.py
+++ b/capcruncher/cli/alignments_filter.py
@@ -65,10 +65,10 @@ def filter(
     sample_name: str = "",
     read_type: str = "",
     gzip: bool = False,
-    output_fragments: bool = True,
-    output_read_stats: bool = True,
-    output_slice_stats: bool = True,
-    output_cis_and_trans_stats: bool = True,
+    fragments: bool = True,
+    read_stats: bool = True,
+    slice_stats: bool = True,
+    cis_and_trans_stats: bool = True,
 
 ):
     """
@@ -139,33 +139,37 @@ def filter(
     # Filter slices using the slice_filter
     slice_filter.filter_slices()
 
-    # Save filtering statisics
-    slice_filter.filter_stats.to_csv(f"{stats_prefix}.slice.stats.csv", index=False)
-    slice_filter.read_stats.to_csv(f"{stats_prefix}.read.stats.csv", index=False)
+    if slice_stats:
+        slice_filter.filter_stats.to_csv(f"{stats_prefix}.slice.stats.csv", index=False)
+    
+    if read_stats:
+        slice_filter.read_stats.to_csv(f"{stats_prefix}.read.stats.csv", index=False)
 
     # Save reporter stats
-    slice_filter.cis_or_trans_stats.to_csv(
-        f"{stats_prefix}.reporter.stats.csv", index=False
-    )
+    if cis_and_trans_stats:
+        slice_filter.cis_or_trans_stats.to_csv(
+            f"{stats_prefix}.reporter.stats.csv", index=False
+        )
 
     # Output slices filtered by capture site
     for capture_site, df_cap in slice_filter.slices.query('capture != "."').groupby(
         "capture"
     ):
 
-        # Extract only fragments that appear in the capture dataframe
-        output_slices = slice_filter.slices.loc[
-            lambda df: df["parent_read"].isin(df_cap["parent_read"])
-        ]
-        # Generate a new slice filterer and extract the fragments
-        output_fragments = slice_filter_type(output_slices).fragments
+        if fragments:
+            # Extract only fragments that appear in the capture dataframe
+            output_slices = slice_filter.slices.loc[
+                lambda df: df["parent_read"].isin(df_cap["parent_read"])
+            ]
+            # Generate a new slice filterer and extract the fragments
+            output_fragments = slice_filter_type(output_slices).fragments
 
-        # Output fragments and slices
-        output_fragments.sort_values("parent_read").to_csv(
-            f"{output_prefix}.{capture_site.strip()}.fragments.tsv{'.gz' if gzip else ''}",
-            sep="\t",
-            index=False,
-        )
+            # Output fragments and slices
+            output_fragments.sort_values("parent_read").to_csv(
+                f"{output_prefix}.{capture_site.strip()}.fragments.tsv{'.gz' if gzip else ''}",
+                sep="\t",
+                index=False,
+            )
 
         output_slices.sort_values("slice_name").to_csv(
             f"{output_prefix}.{capture_site.strip()}.slices.tsv{'.gz' if gzip else ''}",

--- a/capcruncher/cli/alignments_filter.py
+++ b/capcruncher/cli/alignments_filter.py
@@ -46,7 +46,7 @@ def merge_annotations(df: pd.DataFrame, annotations: os.PathLike) -> pd.DataFram
         .drop(columns=["slice_name.1"], errors="ignore")
         .assign(
             restriction_fragment=lambda df: df["restriction_fragment"]
-            .replace(".", 0)
+            .replace(".", -1)
             .astype(int)
         )
         .reset_index()

--- a/capcruncher/cli/cli_alignments.py
+++ b/capcruncher/cli/cli_alignments.py
@@ -107,6 +107,20 @@ def annotate(*args, **kwargs):
 @click.option(
     "--gzip/--no-gzip", help="Determines if files are gziped or not", default=False
 )
+
+@click.option(
+    "--fragments/--no-fragments", help="Determines if read fragment aggregations are produced", default=True
+)
+@click.option(
+    "--read-stats/--no-read-stats", help="Determines if read level statistics are output", default=True
+)
+@click.option(
+    "--slice-stats/--no-slice-stats", help="Determines if slice level statistics are output", default=True
+)
+@click.option(
+    "--cis-and-trans-stats/--no-cis-and-trans-stats", help="Determines cis/trans statistics are output", default=True
+)
+
 def filter(*args, **kwargs):
     """
     Removes unwanted aligned slices and identifies reporters.

--- a/capcruncher/cli/reporters_count.py
+++ b/capcruncher/cli/reporters_count.py
@@ -80,6 +80,10 @@ def count(
 
             print(f'Processing chunk #{ii+1} of {chunksize} slices')
 
+            # Need to remove any restiction fragments that are not in the digested genome
+            df_reporters = df_reporters.query("restriction_fragment != -1")
+
+
             if remove_exclusions:
                 print('Removing exclusions')
                 # Must only remove exclusions if they are relevant for the capture being examined

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1659,6 +1659,8 @@ def reporters_make_bedgraph_normalised(infile, outfile, sample_name):
         "-o",
         output_prefix,
         "--normalise",
+        "--scale_factor",
+        str(P.PARAMS.get("normalisation_scale_factor", 1000000))
     ]
 
     P.run(

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1191,7 +1191,7 @@ def reporters_fragments_collate(infiles, outfile, *grouping_args):
 
 @follows(alignments_filter, mkdir("capcruncher_analysis/reporters/deduplicated"))
 @transform(
-    reporters_collate,
+    reporters_fragments_collate,
     regex(r".*/(?P<sample>.*).(flashed|pe).(?P<capture>.*).fragments.tsv"),
     r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.json.gz",
     extras=[r"\2"],
@@ -1225,9 +1225,9 @@ def alignments_deduplicate_fragments(infile, outfile, read_type):
 
 @follows(alignments_deduplicate_fragments)
 @transform(
-    reporters_collate,
+    "capcruncher_analysis/reporters/identified/*.tsv",
     regex(
-        r"capcruncher_analysis/reporters/collated/(.*)\.(flashed|pe)\.(.*)\.slices.tsv"
+        r".*/(.*)\.(flashed|pe)\.(.*)\.slices.tsv"
     ),
     add_inputs(r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.json.gz"),
     r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.slices.tsv",
@@ -1293,6 +1293,7 @@ def alignments_deduplicate_collate(infiles, outfile, *grouping_args):
         statement.append(cmd)
 
     statement.append(f'cat {tmp} | pigz -p {P.PARAMS["pipeline_n_cores"]} > {outfile}')
+    statement.append(f'rm -f {tmp}')
 
     P.run(
         " && ".join(statement),

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1319,7 +1319,7 @@ def alignments_deduplicate_collate(infiles, outfile, *grouping_args):
         job_condaenv=P.PARAMS["conda_env"],
     )
 
-@follows(alignments_deduplicate_collate)
+@follows(alignments_deduplicate_collate, alignments_deduplicate_slices_statistics)
 @merge(
     "capcruncher_statistics/reporters/data/*",
     "capcruncher_statistics/reporters/reporters.reads.csv",

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -970,17 +970,30 @@ def annotate_sort_blacklist(outfile):
 
     """Sorts the capture oligos for bedtools intersect with --sorted option"""
 
-    if HAS_BLACKLIST:
+    blacklist_file = P.PARAMS.get("analysis_optional_blacklist")
+
+    if HAS_BLACKLIST and blacklist_file.endswith('.bed'):
         statement = [
             "sort",
             "-k1,1",
             "-k2,2n",
-            P.PARAMS["analysis_optional_blacklist"],
+            blacklist_file,
             ">",
             outfile,
         ]
-    else:
+    elif HAS_BLACKLIST and blacklist_file.endswith('.bed.gz'):
+        statement = [
+            "zcat",
+            blacklist_file,
+            "|",
+            "sort",
+            "-k1,1",
+            "-k2,2n",
+            ">",
+            outfile,
+        ]
 
+    else:
         statement = ["touch", outfile]  # Make a blank file if no blacklist
 
     P.run(

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1097,14 +1097,14 @@ def post_annotation():
 @follows(
     post_annotation,
     annotate_alignments,
-    mkdir("capcruncher_analysis/reporters/unfiltered/"),
+    mkdir("capcruncher_analysis/reporters/identified"),
     mkdir("capcruncher_statistics/reporters/data"),
 )
 @transform(
     fastq_alignment,
     regex(r"capcruncher_preprocessing/aligned/(.*).bam"),
     add_inputs(r"capcruncher_analysis/annotations/\1.annotations.tsv"),
-    r"capcruncher_analysis/reporters/unfiltered/\1.completed",
+    r"capcruncher_analysis/reporters/identified\1.completed",
 )
 def alignments_filter(infiles, outfile):
     """Filteres slices and outputs reporter slices for each capture site"""
@@ -1157,14 +1157,14 @@ def alignments_filter(infiles, outfile):
 
 @follows(mkdir("capcruncher_analysis/reporters/collated"), alignments_filter)
 @collate(
-    "capcruncher_analysis/reporters/unfiltered/*.tsv",
+    "capcruncher_analysis/reporters/identified*.tsv",
     regex(
-        r".*/(?P<sample>.*)_part\d+.(flashed|pe).(?P<capture>.*).(slices|fragments).tsv"
+        r".*/(?P<sample>.*)_part\d+.(flashed|pe).(?P<capture>.*).(fragments).tsv"
     ),
     r"capcruncher_analysis/reporters/collated/\1.\2.\3.\4.tsv",
     extras=[r"\1", r"\2", r"\3", r"\4"],
 )
-def reporters_collate(infiles, outfile, *grouping_args):
+def reporters_fragments_collate(infiles, outfile, *grouping_args):
 
     """Concatenates identified reporters"""
 

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1272,6 +1272,22 @@ def alignments_deduplicate_slices(
     zap_file(slices)
 
 
+@transform(alignments_deduplicate_slices, 
+           regex(r".*/(.*)\.(flashed|pe)\.(.*)\.slices.tsv"), 
+           r"capcruncher_statistics/reporters/data/\1_\2_\3.reporter.stats.csv",
+           extras=[r"\1", r"\2", r"\3"],)
+def alignments_deduplicate_slices_statistics(infile, outfile, sample, part, read_type):
+
+    """Task overwrites reporter statistics with de-duplicated statistics"""
+
+    from capcruncher.tools.filter import CCSliceFilter, TriCSliceFilter, TiledCSliceFilter
+
+    filters = {"capture": CCSliceFilter, "tri": TriCSliceFilter, "tiled": TiledCSliceFilter}
+    slice_filterer = filters.get(P.PARAMS['analysis_method'])
+
+    reporter_statistics = slice_filterer(infile).cis_or_trans_statistics.to_csv(outfile)
+
+
 @collate(
     alignments_deduplicate_slices,
     regex(r".*/(?P<sample>.*).(?:flashed|pe).(?P<capture>.*).slices.tsv"),
@@ -1301,6 +1317,14 @@ def alignments_deduplicate_collate(infiles, outfile, *grouping_args):
         job_threads=P.PARAMS["pipeline_n_cores"],
         job_condaenv=P.PARAMS["conda_env"],
     )
+
+
+
+
+
+
+
+
 
 
 @follows(alignments_deduplicate_collate)

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1287,7 +1287,7 @@ def alignments_deduplicate_slices_statistics(infile, outfile, sample, part, read
     slice_filterer = filters.get(P.PARAMS['analysis_method'])
 
     df_slices = pd.read_csv(infile, sep="\t")
-    reporter_statistics = slice_filterer(df_slices).cis_or_trans_statistics.to_csv(outfile)
+    reporter_statistics = slice_filterer(df_slices).cis_or_trans_stats.to_csv(outfile)
 
 
 @collate(

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1286,7 +1286,8 @@ def alignments_deduplicate_slices_statistics(infile, outfile, sample, part, read
     filters = {"capture": CCSliceFilter, "tri": TriCSliceFilter, "tiled": TiledCSliceFilter}
     slice_filterer = filters.get(P.PARAMS['analysis_method'])
 
-    reporter_statistics = slice_filterer(infile).cis_or_trans_statistics.to_csv(outfile)
+    df_slices = pd.read_csv(infile, sep="\t")
+    reporter_statistics = slice_filterer(df_slices).cis_or_trans_statistics.to_csv(outfile)
 
 
 @collate(

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1302,7 +1302,7 @@ def alignments_deduplicate_slices_statistics(
     df_slices = pd.read_csv(infile, sep="\t")
     reporter_statistics = slice_filterer(
         df_slices, sample_name=sample, read_type=read_type
-    ).cis_or_trans_stats.to_csv(outfile)
+    ).cis_or_trans_stats.to_csv(outfile, index=False)
 
 
 @collate(

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1284,7 +1284,7 @@ def alignments_deduplicate_slices_statistics(
     infile, outfile, sample, part, read_type, viewpoint
 ):
 
-    """Task overwrites reporter statistics with de-duplicated statistics"""
+    """Generates reporter statistics from de-duplicated files"""
 
     from capcruncher.tools.filter import (
         CCSliceFilter,
@@ -1300,6 +1300,7 @@ def alignments_deduplicate_slices_statistics(
     slice_filterer = filters.get(P.PARAMS["analysis_method"])
 
     df_slices = pd.read_csv(infile, sep="\t")
+    
     reporter_statistics = slice_filterer(
         df_slices, sample_name=sample, read_type=read_type
     ).cis_or_trans_stats.to_csv(outfile, index=False)

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1228,7 +1228,7 @@ def alignments_deduplicate_fragments(infile, outfile, read_type):
 @transform(
     "capcruncher_analysis/reporters/identified/*.tsv",
     regex(
-        r".*/(?P<sample>.*)\.(?P<partition>.*)\.(?P<read_type>flashed|pe)\.(?P<viewpoint>.*)\.slices.tsv"
+        r".*/(?P<sample>.*)(?P<partition>_part\d+)\.(?P<read_type>flashed|pe)\.(?P<viewpoint>.*)\.slices.tsv"
     ),
     add_inputs(r"capcruncher_analysis/reporters/deduplicated/\1.\3.\4.json.gz"),
     r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.\4.slices.tsv",

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1229,19 +1229,19 @@ def alignments_deduplicate_fragments(infile, outfile, read_type):
 @transform(
     "capcruncher_analysis/reporters/identified/*.tsv",
     regex(
-        r".*/(?P<sample>.*)(?P<partition>_part\d+)\.(?P<read_type>flashed|pe)\.(?P<viewpoint>.*)\.slices.tsv"
+        r".*/(?P<sample>.*)_part(?P<partition>\d+)\.(?P<read_type>flashed|pe)\.(?P<viewpoint>.*)\.slices.tsv"
     ),
     add_inputs(r"capcruncher_analysis/reporters/deduplicated/\1.\3.\4.json.gz"),
     r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.\4.slices.tsv",
-    extras=[r"\1", r"\3", r"\4"],
+    extras=[r"\1", r"\2", r"\3", r"\4"],
 )
-def alignments_deduplicate_slices(infile, outfile, sample_name, read_type, viewpoint):
+def alignments_deduplicate_slices(infile, outfile, sample_name, part, read_type, viewpoint):
 
     """Removes reporters with duplicate coordinates"""
 
     slices, duplicated_ids = infile
     stats_prefix = (
-        f"capcruncher_statistics/reporters/data/{sample_name}_{read_type}_{viewpoint}"
+        f"capcruncher_statistics/reporters/data/{sample_name}_part{part}_{read_type}_{viewpoint}"
     )
 
     statement = [

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1482,6 +1482,8 @@ def reporters_store_binned(infile, outfile, capture_name):
         "--conversion_tables",
         conversion_tables,
         "--normalise",
+        "--scale_factor",
+        str(P.PARAMS.get("normalisation_scale_factor", 1000000)),
         "-p",
         str(P.PARAMS["pipeline_n_cores"]),
         "-o",

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1273,10 +1273,10 @@ def alignments_deduplicate_slices(
 
 
 @transform(alignments_deduplicate_slices, 
-           regex(r".*/(.*)\.(flashed|pe)\.(.*)\.slices.tsv"), 
-           r"capcruncher_statistics/reporters/data/\1_\2_\3.reporter.stats.csv",
-           extras=[r"\1", r"\2", r"\3"],)
-def alignments_deduplicate_slices_statistics(infile, outfile, sample, part, read_type):
+           regex(r".*/(.*)\.(.*)\.(flashed|pe)\.(.*)\.slices.tsv"), 
+           r"capcruncher_statistics/reporters/data/\1_\2_\3_\4.reporter.stats.csv",
+           extras=[r"\1", r"\2", r"\3", r"\4"],)
+def alignments_deduplicate_slices_statistics(infile, outfile, sample, part, read_type, viewpoint):
 
     """Task overwrites reporter statistics with de-duplicated statistics"""
 

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1136,6 +1136,7 @@ def alignments_filter(infiles, outfile):
         sample_name,
         "--read_type",
         sample_read_type,
+        "--no-cis-and-trans-stats", # Need to have the de-duplicated versions of these.
         ">",
         output_log_file,
     ]

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1227,20 +1227,20 @@ def alignments_deduplicate_fragments(infile, outfile, read_type):
 @transform(
     "capcruncher_analysis/reporters/identified/*.tsv",
     regex(
-        r".*/(.*)\.(flashed|pe)\.(.*)\.slices.tsv"
+        r".*/(?P<sample>.*)\.(?P<partition>.*)\.(?P<read_type>flashed|pe)\.(?P<viewpoint>.*)\.slices.tsv"
     ),
-    add_inputs(r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.json.gz"),
-    r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.slices.tsv",
-    extras=[r"\1", r"\2", r"\3"],
+    add_inputs(r"capcruncher_analysis/reporters/deduplicated/\1.\3.\4.json.gz"),
+    r"capcruncher_analysis/reporters/deduplicated/\1.\2.\3.\4.slices.tsv",
+    extras=[r"\1", r"\3", r"\4"],
 )
 def alignments_deduplicate_slices(
-    infile, outfile, sample_name, read_type, capture_oligo
+    infile, outfile, sample_name, read_type, viewpoint
 ):
 
     """Removes reporters with duplicate coordinates"""
 
     slices, duplicated_ids = infile
-    stats_prefix = f"capcruncher_statistics/reporters/data/{sample_name}_{read_type}_{capture_oligo}"
+    stats_prefix = f"capcruncher_statistics/reporters/data/{sample_name}_{read_type}_{viewpoint}"
 
     statement = [
         "capcruncher",

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1290,7 +1290,7 @@ def alignments_deduplicate_slices_statistics(infile, outfile, sample, part, read
 
 @collate(
     alignments_deduplicate_slices,
-    regex(r".*/(?P<sample>.*).(?:flashed|pe).(?P<capture>.*).slices.tsv"),
+    regex(r".*/(?P<sample>.*)\.(?:.*)\.(?:flashed|pe).(?P<capture>.*).slices.tsv"),
     r"capcruncher_analysis/reporters/\1.\2.tsv.gz",
     extras=[r"\1", r"\2"],
 )

--- a/capcruncher/pipeline/pipeline.py
+++ b/capcruncher/pipeline/pipeline.py
@@ -1104,7 +1104,7 @@ def post_annotation():
     fastq_alignment,
     regex(r"capcruncher_preprocessing/aligned/(.*).bam"),
     add_inputs(r"capcruncher_analysis/annotations/\1.annotations.tsv"),
-    r"capcruncher_analysis/reporters/identified\1.completed",
+    r"capcruncher_analysis/reporters/identified/\1.completed",
 )
 def alignments_filter(infiles, outfile):
     """Filteres slices and outputs reporter slices for each capture site"""
@@ -1157,7 +1157,7 @@ def alignments_filter(infiles, outfile):
 
 @follows(mkdir("capcruncher_analysis/reporters/collated"), alignments_filter)
 @collate(
-    "capcruncher_analysis/reporters/identified*.tsv",
+    "capcruncher_analysis/reporters/identified/*.tsv",
     regex(
         r".*/(?P<sample>.*)_part\d+.(flashed|pe).(?P<capture>.*).(fragments).tsv"
     ),
@@ -1189,7 +1189,7 @@ def reporters_fragments_collate(infiles, outfile, *grouping_args):
         zap_file(fn)
 
 
-@follows(alignments_filter, mkdir("capcruncher_analysis/reporters/deduplicated"))
+@follows(mkdir("capcruncher_analysis/reporters/deduplicated"))
 @transform(
     reporters_fragments_collate,
     regex(r".*/(?P<sample>.*).(flashed|pe).(?P<capture>.*).fragments.tsv"),
@@ -1317,15 +1317,6 @@ def alignments_deduplicate_collate(infiles, outfile, *grouping_args):
         job_threads=P.PARAMS["pipeline_n_cores"],
         job_condaenv=P.PARAMS["conda_env"],
     )
-
-
-
-
-
-
-
-
-
 
 @follows(alignments_deduplicate_collate)
 @merge(

--- a/capcruncher/tests/test_cli.py
+++ b/capcruncher/tests/test_cli.py
@@ -381,6 +381,10 @@ def test_alignments_filter():
             output_prefix,
             "--stats_prefix",
             stats_prefix,
+            "--fragments",
+            "--read-stats",
+            "--slice-stats",
+            "--cis-and-trans-stats",
         ],
     )
 

--- a/capcruncher/tools/statistics.py
+++ b/capcruncher/tools/statistics.py
@@ -63,7 +63,15 @@ def collate_slice_data(fnames):
 
 def collate_cis_trans_data(fnames):
 
-    return (pd.concat([pd.read_csv(fn) for fn in fnames])
+    dframes = []
+    for fn in fnames:
+        try:
+            dframes.append(pd.read_csv(fn))
+        except pd.errors.EmptyDataError:
+            pass
+
+
+    return (pd.concat(dframes)
               .groupby(['sample', 'capture', 'read_type', 'cis/trans'])
               .sum()
               .reset_index()

--- a/capcruncher/tools/statistics.py
+++ b/capcruncher/tools/statistics.py
@@ -70,7 +70,6 @@ def collate_cis_trans_data(fnames):
         except pd.errors.EmptyDataError:
             pass
 
-
     return (pd.concat(dframes)
               .groupby(['sample', 'capture', 'read_type', 'cis/trans'])
               .sum()

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,3 +24,4 @@ ignore:
   - "capcruncher/utils.py"
   - "setup.py"
   - "capcruncher/cli/__init__.py"
+  - "capcruncher/tools/statistics.py"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="capcruncher",
-    version="0.1.0a2",
+    version="0.1.1a0",
     author="Alastair Smith",
     author_email="alastair.smith@ndcls.ox.ac.uk",
     packages=find_packages(),


### PR DESCRIPTION
Reporter statistics are currently not using the de-duplicated slices. Historically alignments_filter.py handled the generation of these statistics. Another task has been added to take this role and collation of slices occurs later after de-duplication.

Fixes a bug where fragments missing from the digested genome are assigned to fragment 0. This creates a large spike at the start of chromosome 1.

Version number has been bumped to 0.1.1a0.