### PR TITLE
feat: enable pileups with multiple viewpoint bins

### DIFF
--- a/capcruncher/api/pileup.py
+++ b/capcruncher/api/pileup.py
@@ -139,14 +139,23 @@ class CoolerBedGraph:
                     columns={"chrom": "Chromosome", "start": "Start", "end": "End"}
                 )
             )
-            gr_bdg = (
+
+            df_bdg = (
                 gr_bdg.cluster()
                 .df.groupby("Cluster")
-                .agg({"count": "sum", "Start": "min", "End": "max"})
+                .agg(
+                    {
+                        "count": "sum",
+                        "Start": "min",
+                        "End": "max",
+                        "Chromosome": "first",
+                    }
+                )
+                .reset_index()
+                .rename(
+                    columns={"Start": "start", "End": "end", "Chromosome": "chrom"}
+                )[["chrom", "start", "end", "count"]]
             )
-            df_bdg = gr_bdg.reset_index().rename(
-                columns={"Chromosome": "chrom", "Start": "start", "End": "end"}
-            )[["chrom", "start", "end", "count"]]
 
         if not normalisation == "raw":
             logger.info("Normalising bedgraph")

--- a/capcruncher/pipeline/utils.py
+++ b/capcruncher/pipeline/utils.py
@@ -119,7 +119,7 @@ def get_blacklist(config):
 
 def has_high_viewpoint_number(viewpoints: str, config: Dict):
     n_viewpoints = pr.read_bed(viewpoints).df.shape[0]
-    if n_viewpoints > 100:
+    if n_viewpoints > 500:
         if not config["analysis_optional"].get("force_bigwig_generation", False):
             return True
 

--- a/capcruncher/pipeline/utils.py
+++ b/capcruncher/pipeline/utils.py
@@ -35,7 +35,7 @@ def is_on(param: str) -> bool:
 
 def is_off(param: str):
     """Returns True if parameter in "off" values"""
-    values = ["", "None", "none", "F", "f"]
+    values = ["", "None", "none", "F", "f", "no"]
     if str(param).lower() in values:
         return True
     else:

--- a/capcruncher/pipeline/utils.py
+++ b/capcruncher/pipeline/utils.py
@@ -338,12 +338,12 @@ def validate_custom_filtering(config: Dict):
 def get_count_files(wc, perform_binning: bool = False):
     counts = []
     counts.append(
-        f"capcruncher_output/pileups/counts_by_restriction_fragment/{wc.sample}.hdf5"
+        f"capcruncher_output/interim/pileups/counts_by_restriction_fragment/{wc.sample}.hdf5"
     )
 
     if perform_binning:
         counts.append(
-            f"capcruncher_output/pileups/counts_by_genomic_bin/{wc.sample}.hdf5"
+            f"capcruncher_output/interim/pileups/counts_by_genomic_bin/{wc.sample}.hdf5"
         )
 
     return counts

--- a/capcruncher/pipeline/workflow/rules/filter.smk
+++ b/capcruncher/pipeline/workflow/rules/filter.smk
@@ -113,17 +113,29 @@ rule combine_flashed_and_pe_post_deduplication:
         ),
     output:
         slices=directory("capcruncher_output/results/{sample}/{sample}.parquet"),
+    params:
+        source_dir="capcruncher_output/interim/filtering/deduplicated/{sample}",
+        dest_dir="capcruncher_output/results/{sample}/{sample}.parquet",
     shell:
         """
-        mkdir -p {output.slices}
+        mkdir -p {params.dest_dir}
 
-        for fn in {input.slices[0]}/*.parquet; do
-            mv "$fn" "{output.slices}/flashed-$(basename "$fn")"
+        source_dir="{params.source_dir}"
+        dest_dir="{params.dest_dir}"
+
+        # Move flashed files
+        for fn in "$source_dir/flashed"/*.parquet; do
+            if [ -e "$fn" ]; then
+                mv "$fn" "$dest_dir/flashed-$(basename "$fn")"
+            fi
         done
 
-        for fn in {input.slices[1]}/*.parquet; do
-            mv "$fn" "{output.slices}/pe-$(basename "$fn")"
-        done || mkdir -p {output.slices}
+        # Move pe files
+        for fn in "$source_dir/pe"/*.parquet; do
+            if [ -e "$fn" ]; then
+                mv "$fn" "$dest_dir/pe-$(basename "$fn")"
+            fi
+        done
         """
 
 

--- a/capcruncher/pipeline/workflow/rules/pileup.smk
+++ b/capcruncher/pipeline/workflow/rules/pileup.smk
@@ -5,6 +5,10 @@ def get_mem_mb(wildcards, threads, attempt=0):
     return threads * 3000 * 2 ** (attempt - 1)
 
 
+def get_outdir(wildcards, output):
+    return str(pathlib.Path(output[0]).parent)
+
+
 if CAPCRUNCHER_TOOLS:
 
     rule count:
@@ -22,7 +26,7 @@ if CAPCRUNCHER_TOOLS:
         resources:
             mem_mb=get_mem_mb,
         params:
-            outdir=lambda wc, output: str(pathlib.Path(output).parent),
+            outdir=get_outdir,
             assay=config["analysis"]["method"],
         shell:
             """
@@ -55,7 +59,7 @@ else:
         resources:
             mem_mb=lambda wc, attempt: 3000 * 2**attempt,
         params:
-            outdir=lambda wc, output: str(pathlib.Path(output).parent),
+            outdir=get_outdir,
             assay=config["analysis"]["method"],
         shell:
             """

--- a/capcruncher/pipeline/workflow/rules/pileup.smk
+++ b/capcruncher/pipeline/workflow/rules/pileup.smk
@@ -131,6 +131,7 @@ rule bedgraph_raw:
         bedgraph=temp(
             "capcruncher_output/interim/pileups/bedgraphs/{sample}/raw/{sample}_{viewpoint}.bedgraph"
         ),
+    retries: 0
     log:
         "capcruncher_output/logs/bedgraph_raw/{sample}_{viewpoint}.log",
     params:
@@ -159,6 +160,7 @@ rule bedgraph_normalised:
         ),
     log:
         "capcruncher_output/logs/bedgraph_norm/{sample}_{viewpoint}.log",
+    retries: 0
     params:
         output_prefix=lambda wc, output: pathlib.Path(output.bedgraph).parent
         / f"{wc.sample}",
@@ -186,6 +188,7 @@ rule bedgraph_to_bigwig:
         bedgraph="capcruncher_output/interim/pileups/bedgraphs/{sample}/{norm}/{sample}_{viewpoint}.bedgraph",
     output:
         bigwig="capcruncher_output/results/{sample}/bigwigs/{norm}/{sample}_{viewpoint}.bigWig",
+    retries: 0
     log:
         "capcruncher_output/logs/bedgraph_to_bigwig/{sample}_{norm}_{viewpoint}.log",
     params:
@@ -193,6 +196,6 @@ rule bedgraph_to_bigwig:
     shell:
         """
         sort -k1,1 -k2,2n {input.bedgraph} > {input.bedgraph}.sorted
-        bedGraphToBigWig {input.bedgraph}.sorted {params.chrom_sizes} {output.bigwig}
+        bedGraphToBigWig {input.bedgraph}.sorted {params.chrom_sizes} {output.bigwig} 2> {log}
         rm {input.bedgraph}.sorted
         """

--- a/capcruncher/pipeline/workflow/rules/pileup.smk
+++ b/capcruncher/pipeline/workflow/rules/pileup.smk
@@ -1,5 +1,10 @@
 import capcruncher.pipeline.utils
 
+
+def get_mem_mb(wildcards, threads, attempt=0):
+    return threads * 3000 * 2 ** (attempt - 1)
+
+
 if CAPCRUNCHER_TOOLS:
 
     rule count:
@@ -9,15 +14,15 @@ if CAPCRUNCHER_TOOLS:
             viewpoints=VIEWPOINTS,
         output:
             temp(
-                "capcruncher_output/pileups/counts_by_restriction_fragment/{sample}.hdf5"
+                "capcruncher_output/interim/pileups/counts_by_restriction_fragment/{sample}.hdf5"
             ),
         log:
             "capcruncher_output/logs/counts/{sample}.log",
         threads: 8
         resources:
-            mem_mb=lambda wc, attempt: 3000 * 2**attempt,
+            mem_mb=get_mem_mb,
         params:
-            outdir="capcruncher_output/pileups/counts_by_restriction_fragment",
+            outdir=lambda wc, output: str(pathlib.Path(output).parent),
             assay=config["analysis"]["method"],
         shell:
             """
@@ -42,7 +47,7 @@ else:
             viewpoints=VIEWPOINTS,
         output:
             temp(
-                "capcruncher_output/pileups/counts_by_restriction_fragment/{sample}.hdf5"
+                "capcruncher_output/interim/pileups/counts_by_restriction_fragment/{sample}.hdf5"
             ),
         log:
             "capcruncher_output/logs/counts/{sample}.log",
@@ -50,7 +55,7 @@ else:
         resources:
             mem_mb=lambda wc, attempt: 3000 * 2**attempt,
         params:
-            outdir="capcruncher_output/pileups/counts_by_restriction_fragment",
+            outdir=lambda wc, output: str(pathlib.Path(output).parent),
             assay=config["analysis"]["method"],
         shell:
             """
@@ -71,9 +76,9 @@ else:
 
 rule bin_counts:
     input:
-        "capcruncher_output/pileups/counts_by_restriction_fragment/{sample}.hdf5",
+        "capcruncher_output/interim/pileups/counts_by_restriction_fragment/{sample}.hdf5",
     output:
-        temp("capcruncher_output/pileups/counts_by_genomic_bin/{sample}.hdf5"),
+        temp("capcruncher_output/interim/pileups/counts_by_genomic_bin/{sample}.hdf5"),
     params:
         bin_size=[f"-b {b}" for b in BIN_SIZES],
         assay=config["analysis"]["method"],


### PR DESCRIPTION
Multiple bins per viewpoint prevent bigwig generation due to overlapping fragments.  

This PR enables the implicit ability to deal with these.

In a future update, need to add a validation to check if this is ok before proceeding.