### PR TITLE
chore(deps): Bumped minimum capcruncher-tools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ snakemake_wrapper_utils
 snakemake<=7.32.4
 
 # Essential for CLI
-capcruncher-tools>=0.1.16
+capcruncher-tools>=0.2.0
 coolbox
 cooler<=0.9.2
 h5py


### PR DESCRIPTION
* Removes a bug in capcruncher genome digest where lowercase sequence was ignored.