### PR TITLE
PR 01: Raise packaging baseline to Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,42 @@ The CapCruncher package is designed to process Capture-C, Tri-C and Tiled-C data
 >
 > CapCruncher is currently only availible for linux with MacOS support planned in the future.
 
-CapCruncher is available on conda and PyPI. To install the latest version, run:
+CapCruncher requires Python 3.12 or newer.
+
+CapCruncher is available on conda and PyPI. For a standard install, create a fresh Python 3.12 environment and install the package with pip:
 
 ``` bash
-pip install capcruncher
+mamba create -n cc python=3.12
+conda activate cc
+python -m pip install --upgrade pip
+python -m pip install capcruncher
 ```
 
-or
+If you also want the optional plotting and analysis extras, install:
+
+``` bash
+python -m pip install 'capcruncher[full]'
+```
+
+Bioconda remains available for fully managed installs:
 
 ``` bash
 mamba install -c bioconda capcruncher
 ```
 
-Please note that it is highly recommended to install CapCruncher in a conda environment. If you do not have conda installed, please follow the instructions [here](https://github.com/conda-forge/miniforge#mambaforge) to install mambaforge.
+For development or editable installs, `uv` provides the shortest path on Python 3.12+:
 
-See the [installation guide](installation.md) for more detailed instructions.
+``` bash
+uv python install 3.12
+uv venv --python 3.12 .venv
+source .venv/bin/activate
+uv pip install -e '.[full]'
+capcruncher --help
+```
+
+It is still recommended to use a conda-compatible environment for the native command-line dependencies used by the pipeline. If you do not have conda installed, please follow the [Miniforge installation instructions](https://github.com/conda-forge/miniforge#mambaforge).
+
+See the [installation guide](docs/installation.md) for the full pip, conda, and `uv` workflows.
 
 ### Usage
 

--- a/capcruncher/cli/__init__.py
+++ b/capcruncher/cli/__init__.py
@@ -6,6 +6,13 @@ from loguru import logger
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
+def get_capcruncher_version() -> str:
+    try:
+        return metadata.version(distribution_name="capcruncher")
+    except metadata.PackageNotFoundError:
+        return "0+unknown"
+
+
 class UnsortedGroup(click.Group):
     def list_commands(self, ctx):
         return list(self.commands)
@@ -45,7 +52,7 @@ class LazyGroup(click.Group):
 
 
 @click.group(cls=UnsortedGroup)
-@click.version_option(metadata.version(distribution_name="capcruncher"))
+@click.version_option(get_capcruncher_version())
 def cli():
     """
     An end to end solution for processing: Capture-C, Tri-C and Tiled-C data.

--- a/capcruncher/cli/cli_pipeline.py
+++ b/capcruncher/cli/cli_pipeline.py
@@ -1,7 +1,6 @@
 import os
-from capcruncher.cli import cli
+from capcruncher.cli import cli, get_capcruncher_version
 import click
-from importlib import metadata
 import subprocess
 import sys
 import pathlib
@@ -16,7 +15,7 @@ import pathlib
     help="Show the capcruncher logo",
     show_default=True,
 )
-@click.version_option(metadata.version(distribution_name="capcruncher"))
+@click.version_option(get_capcruncher_version())
 @click.argument("pipeline_options", nargs=-1, type=click.UNPROCESSED)
 def pipeline(pipeline_options, show_help=False, show_version=False, logo=True):
     """Runs the data processing pipeline"""
@@ -86,7 +85,7 @@ def pipeline(pipeline_options, show_help=False, show_version=False, logo=True):
 @cli.command(name="pipeline-config")
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.option("--version", "show_version", is_flag=True)
-@click.version_option(metadata.version(distribution_name="capcruncher"))
+@click.version_option(get_capcruncher_version())
 @click.option(
     "-i", "--input", "input_files", type=click.Path(exists=True), multiple=True
 )

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,9 @@
 
 ## Setup
 
-It is highly recommended to install CapCruncher in a conda environment. If you do not have conda installed, see the detailed [conda installation section](#detailed-conda-installation).
+CapCruncher requires Python 3.12 or newer.
+
+For end users, it is still highly recommended to install CapCruncher in a conda-compatible environment because the pipeline depends on several native bioinformatics tools. If you do not have conda installed, see the detailed [conda installation section](#detailed-conda-installation-instructions).
 
 ## Dependencies
 
@@ -27,24 +29,43 @@ mamba install -c bioconda capcruncher
 
 #### Two-step installation using conda and pip
 
-Alternatively, create a new conda environment and install CapCruncher using pip (currently the recommended method):
+Alternatively, create a new conda environment from the checked-in environment definition and install CapCruncher with pip (currently the recommended method):
 
 
 ```{bash}
 wget https://raw.githubusercontent.com/sims-lab/CapCruncher/master/environment.yml
 conda env create -f environment.yml
 conda activate cc
+python -m pip install --upgrade pip
 
 # Install CapCruncher using pip
-pip install capcruncher
-s
+python -m pip install capcruncher
+
 # Optional - highly recommended to install the optional dependencies
-# Installs dependencies for:
-# * plotting,
-# * differential interaction analysis
-# * speeding up the pipeline using experimental features (capcruncher-tools)
-pip install capcruncher[full]
+# Installs the plotting and analysis extras defined by the package.
+python -m pip install 'capcruncher[full]'
 ```
+
+The bundled [environment.yml](https://raw.githubusercontent.com/sims-lab/CapCruncher/master/environment.yml) now creates a Python 3.12 environment and installs the non-Python tools needed by the pipeline.
+
+### Editable development install with uv
+
+For local development, `uv` is the shortest way to get an isolated editable install on Python 3.12+:
+
+```{bash}
+git clone https://github.com/sims-lab/CapCruncher.git
+cd CapCruncher
+
+uv python install 3.12
+uv venv --python 3.12 .venv
+source .venv/bin/activate
+uv pip install -e '.[full]'
+
+# Cheap smoke check for the editable install
+capcruncher --help
+```
+
+Use this path when you are changing Python code or running the test suite. Use the conda environment above when you need the full set of external command-line tools that the pipeline shells out to.
 
 ### Install CapCruncher in a minimal conda environment and use singularity to run the pipeline
 
@@ -55,10 +76,19 @@ pip install capcruncher[full]
 Create a minimal conda environment and install CapCruncher using pip:
 
 ```{bash}
-mamba create -n cc "python>=3.10"
+mamba create -n cc python=3.12
 conda activate cc
+python -m pip install --upgrade pip
+
+# Install the package and optional extras from PyPI
+python -m pip install 'capcruncher[full]'
+```
+
+If you are working from a local checkout instead of PyPI, replace the last command with:
+
+```{bash}
 # Optional - highly recommended to install the optional dependencies
-pip install capcruncher[stats,plotting,experimental]
+python -m pip install -e '.[full]'
 ```
 
 
@@ -75,16 +105,17 @@ Clone the repository and install CapCruncher using pip:
 ```{bash}
 git clone https://github.com/sims-lab/CapCruncher.git
 cd CapCruncher
-pip install .
+python -m pip install --upgrade pip
+python -m pip install .
 
 # Optional - highly recommended to install the optional dependencies
-pip install .[stats,plotting,experimental]
+python -m pip install '.[full]'
 ```
 
 
 ## Detailed Conda Installation Instructions
 
-Download and install MambaForge from [here](https://github.com/conda-forge/miniforge#mambaforge) for your system (You will typically need the x86_64 version for most Linux systems).
+Download and install MambaForge by following the [Miniforge installation instructions](https://github.com/conda-forge/miniforge#mambaforge) for your system. You will typically need the x86_64 installer on most Linux systems.
 
 ### Download and run the installer for your system (only Linux is supported at the moment)
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - python=3.12
   - bedtools<=2.31.0
   - bowtie2>=2.4.4
   - cxx-compiler

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - fastqc<=0.12.1
   - flash<=1.2.11
   - git
-  - iced<=0.5.10
   - jupyterlab
   - pairix
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "An end-to-end solution for processing Capture-C, Tri-C and Tiled-C data"
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import pytest
 import os
 from click.testing import CliRunner
 import glob
+import capcruncher.cli as cli_module
 
 from capcruncher.cli import cli
 
@@ -81,6 +82,15 @@ def test_cli_runs(cli_runner):
 
     result = cli_runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
+
+
+def test_cli_version_without_installed_metadata(cli_runner, monkeypatch):
+    def raise_package_not_found(*args, **kwargs):
+        raise cli_module.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(cli_module.metadata, "version", raise_package_not_found)
+
+    assert cli_module.get_capcruncher_version() == "0+unknown"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- raise the published Python baseline to 3.12 and pin the checked-in conda environment accordingly
- document the updated pip, conda, and uv installation flows
- make CLI version reporting resilient when CapCruncher is imported from a source checkout without installed metadata

## Validation
- `.venv/bin/python -m pytest tests/test_cli.py -k "test_cli_runs or test_cli_version_without_installed_metadata" -q`
- `.venv/bin/capcruncher --help`

## Deferred
- dependency modernization beyond the Python floor
- Snakemake 9 workflow and preset changes
- interval, plotting, container, and docs integration work planned for later PRs