### PR TITLE
PR 02: Migrate interval stack to PyRanges1

### DIFF
--- a/capcruncher/api/annotate.py
+++ b/capcruncher/api/annotate.py
@@ -2,12 +2,15 @@ import warnings
 from typing import Union, List, Literal
 
 import pandas as pd
-import pybedtools
-import pyranges as pr
+import pyranges1 as pr
 import numpy as np
 from pandas.api.types import is_categorical_dtype, is_numeric_dtype
 
 from capcruncher.utils import convert_bed_to_pr
+
+
+def _pyranges_frame(gr: pr.PyRanges) -> pd.DataFrame:
+    return pd.DataFrame(gr).copy()
 
 warnings.simplefilter("ignore", category=RuntimeWarning)
 
@@ -56,7 +59,7 @@ def remove_duplicates_from_bed(
         pr.PyRanges: Deduplicated PyRanges object.
     """
 
-    df = bed.df.rename(columns=lambda col: col.lower()).rename(
+    df = _pyranges_frame(bed).rename(columns=lambda col: col.lower()).rename(
         columns={"chromosome": "chrom"}
     )
 
@@ -106,13 +109,15 @@ class Intersection:
 
 class IntersectionGet(Intersection):
     def get_new_dtype(self):
-        # Determine the dtype of the name column
-        if is_numeric_dtype(self.b.df["Name"]):
-            dtype_new = self.b.df["Name"].dtype
+        bed_b = _pyranges_frame(self.b)
 
-        elif is_categorical_dtype(self.b.df["Name"]):
-            if is_numeric_dtype(self.b.df["Name"].cat.categories):
-                dtype_new = self.b.df["Name"].cat.categories.dtype
+        # Determine the dtype of the name column
+        if is_numeric_dtype(bed_b["Name"]):
+            dtype_new = bed_b["Name"].dtype
+
+        elif is_categorical_dtype(bed_b["Name"]):
+            if is_numeric_dtype(bed_b["Name"].cat.categories):
+                dtype_new = bed_b["Name"].cat.categories.dtype
                 numeric_dtype_mapping = {
                     "int64": "Int64",
                     "float64": "Float64",
@@ -122,10 +127,10 @@ class IntersectionGet(Intersection):
                 dtype_new = numeric_dtype_mapping.get(str(dtype_new), "Int64")
 
             else:
-                dtype_new = self.b.df["Name"].dtype
+                dtype_new = bed_b["Name"].dtype
 
         else:
-            dtype_new = pd.CategoricalDtype([*self.b.df["Name"].unique().astype(str)])
+            dtype_new = pd.CategoricalDtype([*bed_b["Name"].unique().astype(str)])
 
         return dtype_new
 
@@ -133,24 +138,18 @@ class IntersectionGet(Intersection):
     def intersection(self) -> pr.PyRanges:
         dtype_new = self.get_new_dtype()
 
-        # Hack to get around the fact that pyranges has a bug when joining categorical columns
-        # See https://github.com/pyranges/pyranges/issues/230
-
-        df_overlapping = self.a.join(
-            self.b, nb_cpu=self.n_cores, report_overlap=True
-        ).df
-
-        if not df_overlapping.empty:
-            df_non_overlapping = self.a.df.loc[
-                lambda df: ~df.Name.isin(df_overlapping.Name)
-            ]
-        else:
-            raise ValueError("No overlapping regions found")
-
-        df_both = pd.concat([df_overlapping, df_non_overlapping]).sort_values("Name")
+        df_both = pd.DataFrame(
+            self.a.join_overlaps(
+                self.b,
+                join_type="left",
+                report_overlap_column="Overlap",
+            )
+        ).sort_values("Name")
 
         # Filter out the non-overlapping regions
-        df_both["frac"] = df_both.eval("Overlap / (End - Start)")
+        df_both["frac"] = df_both["Overlap"].fillna(0).div(
+            df_both["End"] - df_both["Start"]
+        )
         df_both[self.name] = np.where(
             df_both["frac"] >= self.fraction, df_both["Name_b"], pd.NA
         )
@@ -176,22 +175,24 @@ class IntersectionGet(Intersection):
 class IntersectionCount(Intersection):
     @property
     def intersection(self) -> pr.PyRanges:
-        return (
-            self.a.coverage(self.b, nb_cpu=self.n_cores)
-            .df.assign(
-                **{
-                    self.name: lambda df: pd.Series(
-                        np.where(
-                            (df["NumberOverlaps"] > 0)
-                            & (df["FractionOverlaps"] >= self.fraction),
-                            df["NumberOverlaps"],
-                            0,
-                        )
-                    ).astype(pd.Int8Dtype())
-                }
+        joined = pd.DataFrame(
+            self.a.join_overlaps(self.b, report_overlap_column="Overlap")
+        )
+
+        bed_a = _pyranges_frame(self.a)
+        if joined.empty:
+            counts = pd.Series(0, index=bed_a["Name"], dtype="int64")
+        else:
+            joined["fraction"] = joined["Overlap"] / (joined["End"] - joined["Start"])
+            counts = (
+                joined.loc[joined["fraction"] >= self.fraction]
+                .groupby("Name")
+                .size()
+                .reindex(bed_a["Name"], fill_value=0)
             )
-            .drop(columns=["NumberOverlaps", "FractionOverlaps"])
-            .pipe(pr.PyRanges)
+
+        return pr.PyRanges(
+            bed_a.assign(**{self.name: counts.to_numpy(dtype="int64")})
         )
 
 
@@ -199,7 +200,7 @@ class IntersectionFailed(Intersection):
     @property
     def intersection(self):
         return (
-            self.a.df.assign(**{self.name: pd.NA})
+            _pyranges_frame(self.a).assign(**{self.name: pd.NA})
             .assign(**{self.name: lambda df: df[self.name].astype(pd.StringDtype())})
             .pipe(pr.PyRanges)
         )
@@ -218,18 +219,18 @@ class BedIntersector:
 
         if isinstance(bed_a, pr.PyRanges):
             self.a = self.process_bed(bed_a)
-        elif isinstance(bed_a, (str, pybedtools.BedTool, pd.DataFrame)):
+        elif isinstance(bed_a, (str, pd.DataFrame)):
             self.a = convert_bed_to_pr(bed_a)
             self.a = self.process_bed(self.a)
         else:
             raise ValueError(
-                f"bed_a must be of type str, pybedtools.BedTool, or pr.PyRanges. Got {type(bed_a)}"
+                f"bed_a must be of type str, pd.DataFrame, or pr.PyRanges. Got {type(bed_a)}"
             )
 
         self.b = bed_b if isinstance(bed_b, pr.PyRanges) else convert_bed_to_pr(bed_b)
         self.name = name
         self.fraction = fraction
-        self.n_cores = max_cores if self.b.df.shape[0] > 50_000 else 1
+        self.n_cores = max_cores if len(self.b) > 50_000 else 1
 
     def get_intersection(self, method: Literal["get", "count"] = "get") -> pr.PyRanges:
         try:
@@ -265,22 +266,22 @@ class BedIntersector:
         # If there are annotation columns, join them to the intersection
         if not self.annotation.empty:
             _intersection = (
-                _intersection.df.set_index("Name")
+                _pyranges_frame(_intersection).set_index("Name")
                 .join(self.annotation, how="left")
                 .reset_index()
                 .pipe(pr.PyRanges)
             )
 
         # Put the original name back
-        _intersection = _intersection.df.assign(
+        _intersection = _pyranges_frame(_intersection).assign(
             Name=lambda df: df.Name.map(self.original_name_mapping)
         )
 
-        return pr.PyRanges(df=_intersection)
+        return pr.PyRanges(_intersection)
 
     def process_bed(self, bed: pr.PyRanges):
         # Convert to dataframe
-        bed = bed.df
+        bed = _pyranges_frame(bed)
 
         # Create a unique identifier for each slice
         self.uid = pd.util.hash_pandas_object(

--- a/capcruncher/api/pileup.py
+++ b/capcruncher/api/pileup.py
@@ -1,14 +1,13 @@
 import pandas as pd
 import numpy as np
-from pybedtools import BedTool
 import cooler
 from typing import Literal
 from capcruncher.api.storage import CoolerBinner
-from capcruncher.utils import is_valid_bed
+from capcruncher.utils import convert_bed_to_pr, is_valid_bed
 from loguru import logger
 import ray
 import re
-import pyranges as pr
+import pyranges1 as pr
 
 
 class CoolerBedGraph:
@@ -141,8 +140,7 @@ class CoolerBedGraph:
             )
 
             df_bdg = (
-                gr_bdg.cluster()
-                .df.groupby("Cluster")
+                pd.DataFrame(gr_bdg.cluster_overlaps()).groupby("Cluster")
                 .agg(
                     {
                         "count": "sum",
@@ -367,7 +365,7 @@ class CCBedgraph(object):
         return self.df.loc[:, "chrom":"end"]
 
     def to_bedtool(self):
-        return self.df.pipe(BedTool.from_dataframe)
+        return self.df.copy()
 
     def to_file(self, path):
         self.df.to_csv(path, sep="\t", header=None, index=None)
@@ -457,9 +455,9 @@ def cooler_to_bedgraph(
         pr_bedgraph = bedgraph.rename(
             columns={"chrom": "Chromosome", "start": "Start", "end": "End"}
         ).pipe(pr.PyRanges)
-        pr_bedgraph = pr_bedgraph.join(pr_roi, strandedness="same")
+        pr_bedgraph = pr_bedgraph.join_overlaps(pr_roi, strand_behavior="same")
 
-        bedgraph = pr_bedgraph.df.rename(
+        bedgraph = pd.DataFrame(pr_bedgraph).rename(
             columns={"Chromosome": "chrom", "Start": "start", "End": "end"}
         )[["chrom", "start", "end", "score"]]
 

--- a/capcruncher/api/plotting.py
+++ b/capcruncher/api/plotting.py
@@ -25,15 +25,15 @@ try:
     import matplotlib.pyplot as plt
     import numpy as np
     import pandas as pd
-    import pyranges as pr
+    import pyranges1 as pr
     import seaborn as sns
     import tqdm
     from matplotlib import cm, colors, transforms
     from matplotlib.colors import LinearSegmentedColormap
     from matplotlib.patches import Polygon
-    from pybedtools import BedTool
 
     import capcruncher.api as cc
+    from capcruncher.utils import fetch_bed_intervals
 
 
 
@@ -398,10 +398,12 @@ try:
             return df_intervals
 
         def fetch_exluded_regions(self, gr):
-            excluded_tabix = BedTool(self.exclusions).tabix(force=True)
-            df_excluded = excluded_tabix.tabix_intervals(
-                f"{gr.chrom}:{gr.start}-{gr.end}"
-            ).to_dataframe()
+            df_excluded = fetch_bed_intervals(
+                self.exclusions, f"{gr.chrom}:{gr.start}-{gr.end}"
+            )
+
+            if df_excluded.empty:
+                return pd.DataFrame(columns=["bp", "mean", "sem"])
 
             intervals_to_bp = []
             for interval in df_excluded.itertuples():
@@ -621,12 +623,7 @@ try:
             self.properties.update(kwargs)
 
         def fetch_data(self, gr):
-            bt = BedTool(self.file)
-            bt_tabix = bt.tabix(force=True)
-
-            return bt_tabix.tabix_intervals(
-                f"{gr.chrom}:{gr.start}-{gr.end}"
-            ).to_dataframe()
+            return fetch_bed_intervals(self.file, f"{gr.chrom}:{gr.start}-{gr.end}")
 
         def plot(self, ax, gr, **kwargs):
             data = self.fetch_data(gr)

--- a/capcruncher/api/storage.py
+++ b/capcruncher/api/storage.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import pandas as pd
 import numpy as np
-from pybedtools import BedTool
 import cooler
 import h5py
 import functools
@@ -10,9 +9,13 @@ import itertools
 from loguru import logger
 import ujson
 from typing import Iterable, Tuple, Union, List, Dict, Literal
-import pyranges as pr
+import pyranges1 as pr
 import re
 from dataclasses import dataclass
+
+
+def _pyranges_to_dataframe(gr: pr.PyRanges) -> pd.DataFrame:
+    return pd.DataFrame(gr).copy()
 
 
 class Viewpoint:
@@ -40,7 +43,7 @@ class Viewpoint:
             Viewpoint: Viewpoint object.
         """
         gr_viewpoints = pr.read_bed(bed)
-        df_viewpoints = gr_viewpoints.as_df()
+        df_viewpoints = _pyranges_to_dataframe(gr_viewpoints)
 
         df_viewpoints = df_viewpoints.loc[
             lambda df: df["Name"].str.contains(f"{viewpoint}$")
@@ -63,10 +66,10 @@ class Viewpoint:
         Returns:
             pr.PyRanges: PyRanges object containing all bins that overlap with the viewpoint.
         """
-        return bins.join(self.coordinates)
+        return bins.join_overlaps(self.coordinates)
 
     def bin_names(self, bins: pr.PyRanges) -> List[int]:
-        return self.bins(bins).df["Name"].astype(int).to_list()
+        return _pyranges_to_dataframe(self.bins(bins))["Name"].astype(int).to_list()
 
     def bins_cis(self, bins: pr.PyRanges) -> List[int]:
         """
@@ -83,7 +86,7 @@ class Viewpoint:
         viewpoint_chromosomes = self.chromosomes
 
         # Get the bins that are on the same chromosome(s) as the viewpoint
-        df_cis_bins = bins.df.loc[
+        df_cis_bins = _pyranges_to_dataframe(bins).loc[
             lambda df: df["Chromosome"].isin(viewpoint_chromosomes)
         ]
 
@@ -97,7 +100,7 @@ class Viewpoint:
 
     @property
     def chromosomes(self) -> List[str]:
-        return self.coordinates.df["Chromosome"].unique().tolist()
+        return _pyranges_to_dataframe(self.coordinates)["Chromosome"].unique().tolist()
 
     @property
     def coords(self) -> List[str]:
@@ -108,7 +111,7 @@ class Viewpoint:
             List[str]: List of genomic coordinates.
         """
         _coords = []
-        for row in self.coordinates.df.itertuples():
+        for row in _pyranges_to_dataframe(self.coordinates).itertuples():
             _coords.append(f"{row.Chromosome}:{row.Start}-{row.End}")
 
         return _coords
@@ -267,7 +270,7 @@ class CoolerBinner:
 
         if self.method == "midpoint":
             fragment_bins = (
-                fragment_bins.as_df()
+                _pyranges_to_dataframe(fragment_bins)
                 .assign(
                     Start=lambda df: df["Start"] + (df["End"] - df["Start"]) / 2,
                     End=lambda df: df["Start"] + 1,
@@ -275,8 +278,10 @@ class CoolerBinner:
                 .pipe(pr.PyRanges)
             )
 
-        pr_fragment_to_bins = self.genomic_bins.join(
-            fragment_bins, strandedness=0, how=None, report_overlap=True
+        pr_fragment_to_bins = self.genomic_bins.join_overlaps(
+            fragment_bins,
+            strand_behavior="ignore",
+            report_overlap_column="Overlap",
         )
 
         if self.method == "overlap":
@@ -298,7 +303,7 @@ class CoolerBinner:
         Translate genomic bins to fragment bins
         """
         fragment_to_bins_mapping = (
-            self.fragment_to_genomic_table.as_df()
+            _pyranges_to_dataframe(self.fragment_to_genomic_table)
             .set_index("fragment_id")["genomic_bin_id"]
             .to_dict()
         )
@@ -329,7 +334,7 @@ class CoolerBinner:
         # Normalize pixels if specified
         if self.n_restriction_fragment_correction:
             n_fragments_per_bin = (
-                self.fragment_to_genomic_table.as_df()
+                _pyranges_to_dataframe(self.fragment_to_genomic_table)
                 .set_index("genomic_bin_id")["n_fragments_per_bin"]
                 .to_dict()
             )
@@ -369,14 +374,12 @@ class CoolerBinner:
         Return list of viewpoint bins
         """
 
-        pr_viewpoint = pr.from_dict(
+        pr_viewpoint = pr.PyRanges(
             dict(
                 zip(
                     ["Chromosome", "Start", "End"],
                     [
-                        [
-                            x,
-                        ]
+                        [x]
                         for x in re.split(
                             ":|-", self.cooler.info["metadata"]["viewpoint_coords"][0]
                         )
@@ -385,7 +388,9 @@ class CoolerBinner:
             )
         )
 
-        return pr_viewpoint.join(self.genomic_bins).df["genomic_bin_id"].to_list()
+        return _pyranges_to_dataframe(
+            pr_viewpoint.join_overlaps(self.genomic_bins)
+        )["genomic_bin_id"].to_list()
 
     def to_cooler(self, store: os.PathLike):
         metadata = {**self.cooler.info["metadata"]}
@@ -412,7 +417,7 @@ class CoolerBinner:
         )
 
         bins = (
-            self.genomic_bins.df.rename(
+            _pyranges_to_dataframe(self.genomic_bins).rename(
                 columns={"Chromosome": "chrom", "Start": "start", "End": "end"}
             )
             .sort_values("genomic_bin_id")

--- a/capcruncher/cli/alignments_annotate.py
+++ b/capcruncher/cli/alignments_annotate.py
@@ -4,12 +4,12 @@ import warnings
 from typing import Tuple
 
 import pandas as pd
-import pyranges as pr
+import pyranges1 as pr
 from loguru import logger
-from pybedtools import BedTool
 
 from capcruncher.api.annotate import remove_duplicates_from_bed, BedIntersector
 from capcruncher.utils import (
+    bam_to_bed_dataframe,
     convert_bed_to_pr,
     cycle_argument,
     hash_column,
@@ -70,22 +70,22 @@ def annotate(
 
         if slices == "-":
             logger.info("Reading slices from stdin")
-            slices = pd.read_csv(sys.stdin, sep="\t", header=None).pipe(pr.PyRanges)
+            slices = pd.read_csv(sys.stdin, sep="\t", header=None).pipe(convert_bed_to_pr)
 
         elif slices.endswith(".bam"):
             logger.info("Converting bam to bed")
-            slices = BedTool(slices).bam_to_bed().to_dataframe().pipe(convert_bed_to_pr)
+            slices = bam_to_bed_dataframe(slices).pipe(convert_bed_to_pr)
 
         else:
-            slices = pr.PyRanges(slices)
+            slices = convert_bed_to_pr(slices)
 
         logger.info("Validating input bed file before annotation")
 
         if blacklist:
             try:
                 logger.info("Removing blacklisted regions from the bed file")
-                gr_blacklist = pr.PyRanges(blacklist)
-                slices.subtract(gr_blacklist)
+                gr_blacklist = convert_bed_to_pr(blacklist)
+                slices = slices.subtract_overlaps(gr_blacklist)
             except Exception as e:
                 logger.warning(
                     f"Failed to remove blacklisted regions from the bed file. {e}"
@@ -123,7 +123,7 @@ def annotate(
             
 
         logger.info("Writing annotations to file.")
-        df_annotation = slices.df.rename(columns={"Name": "slice_name"}).assign(
+        df_annotation = pd.DataFrame(slices).rename(columns={"Name": "slice_name"}).assign(
             slice_id=lambda df: hash_column(df.slice_name)
         )
         df_annotation.to_parquet(output, compression="snappy")

--- a/capcruncher/cli/cli_utilities.py
+++ b/capcruncher/cli/cli_utilities.py
@@ -10,7 +10,7 @@ from ibis import _
 from loguru import logger
 
 from capcruncher.api.statistics import CisOrTransStats
-from capcruncher.utils import get_file_type
+from capcruncher.utils import bam_to_bed_dataframe, convert_bed_to_pr, get_file_type
 
 
 @click.group()
@@ -33,12 +33,25 @@ def gtf_to_bed12(gtf: str, output: str):
         None
     """
 
-    from pybedtools import BedTool
-
     from capcruncher.utils import gtf_line_to_bed12_line
 
-    bt_gtf = BedTool(gtf)
-    df_gtf = bt_gtf.to_dataframe()
+    df_gtf = pd.read_csv(
+        gtf,
+        sep="\t",
+        comment="#",
+        header=None,
+        names=[
+            "seqname",
+            "source",
+            "feature",
+            "start",
+            "end",
+            "score",
+            "strand",
+            "frame",
+            "attributes",
+        ],
+    )
     df_gtf["geneid"] = df_gtf["attributes"].str.extract(r"gene_id\s?\"(.*?)\";.*")
     df_gtf = df_gtf.query('feature.isin(["5UTR", "3UTR", "exon"])')
     df_gtf = df_gtf.loc[
@@ -197,13 +210,11 @@ def viewpoint_coordinates(
         ValueError: If no bowtie2 indices are supplied
     """
 
-    from pybedtools import BedTool
-
     from capcruncher.cli import genome_digest
 
     digested_genome = NamedTemporaryFile("r+")
     viewpoints_fasta = NamedTemporaryFile("r+")
-    viewpoints_aligned_bam = NamedTemporaryFile("r+")
+    viewpoints_aligned_bam = NamedTemporaryFile(suffix=".bam")
 
     genome_digest.digest(
         input_fasta=genome,
@@ -242,18 +253,17 @@ def viewpoint_coordinates(
     aligned_res = p_bam.communicate()
 
     # Intersect digested genome with viewpoints
-    bt_genome = BedTool(digested_genome.name)
-    bt_viewpoints = BedTool(viewpoints_aligned_bam.name)
-
-    intersections = bt_genome.intersect(bt_viewpoints, wa=True, wb=True)
+    intersections = convert_bed_to_pr(digested_genome.name).join_overlaps(
+        bam_to_bed_dataframe(viewpoints_aligned_bam.name).pipe(convert_bed_to_pr)
+    )
 
     # Write results to file
     (
-        intersections.to_dataframe()
-        .drop_duplicates("name")
-        .assign(oligo_name=lambda df: df["thickEnd"].str.split("_L").str[0])[
-            ["chrom", "start", "end", "oligo_name"]
-        ]
+        pd.DataFrame(intersections).rename(
+            columns={"Chromosome": "chrom", "Start": "start", "End": "end"}
+        )
+        .assign(oligo_name=lambda df: df["Name_b"].str.split("_L").str[0])
+        .drop_duplicates("oligo_name")[["chrom", "start", "end", "oligo_name"]]
         .to_csv(output, index=False, header=False, sep="\t")
     )
 
@@ -412,7 +422,7 @@ def make_chicago_maps(fragments: str, viewpoints: str, outputdir: str):
     Bait map file (.baitmap) - a bed file containing coordinates of the baited restriction fragments, and their associated annotations. By default, 5 columns: chr, start, end, fragmentID, baitAnnotation. The regions specified in this file, including their fragmentIDs, must be an exact subset of those in the .rmap file. The baitAnnotation is a text field that is used only to annotate the output and plots.
     """
     import pathlib
-    import pyranges as pr
+    import pyranges1 as pr
 
     # Rename fragments file to suit chicago
     fragments_new = pathlib.Path(outputdir) / (pathlib.Path(fragments).stem + ".rmap")
@@ -424,8 +434,9 @@ def make_chicago_maps(fragments: str, viewpoints: str, outputdir: str):
     fragments = pr.read_bed(fragments)
 
     df_baitmap = (
-        fragments.join(viewpoints, suffix="_vp")
-        .df[['Chromosome', 'Start', 'End', 'Name', 'Name_vp']]
+        pd.DataFrame(fragments.join_overlaps(viewpoints, suffix="_vp"))[
+            ["Chromosome", "Start", "End", "Name", "Name_vp"]
+        ]
         .rename(
             columns={
                 "Chromosome": "chr",

--- a/capcruncher/cli/interactions_compare.py
+++ b/capcruncher/cli/interactions_compare.py
@@ -12,7 +12,6 @@ import polars as pl
 from capcruncher.api.pileup import CoolerBedGraph
 from capcruncher.utils import get_cooler_uri
 from joblib import Parallel, delayed
-from pybedtools import BedTool
 from collections import defaultdict
 
 
@@ -32,6 +31,72 @@ def remove_duplicate_entries(df: pd.DataFrame) -> pd.DataFrame:
         .reset_index()
         .sort_values(["chrom", "start", "end"])
     )
+
+
+def _read_bedgraph(path: os.PathLike, value_column: str) -> pd.DataFrame:
+    return pd.read_csv(
+        path,
+        sep="\t",
+        header=None,
+        names=["chrom", "start", "end", value_column],
+    )
+
+
+def _segment_union_for_chrom(
+    chrom: str, bedgraphs: Dict[str, pd.DataFrame]
+) -> pd.DataFrame:
+    breakpoints = sorted(
+        {
+            point
+            for dataframe in bedgraphs.values()
+            for row in dataframe.loc[dataframe["chrom"] == chrom, ["start", "end"]].itertuples(index=False)
+            for point in row
+        }
+    )
+
+    if len(breakpoints) < 2:
+        return pd.DataFrame(columns=["chrom", "start", "end", *bedgraphs.keys()])
+
+    union = pd.DataFrame(
+        {
+            "chrom": chrom,
+            "start": breakpoints[:-1],
+            "end": breakpoints[1:],
+        }
+    )
+
+    for name, dataframe in bedgraphs.items():
+        intervals = dataframe.loc[dataframe["chrom"] == chrom, ["start", "end", name]].sort_values("start")
+        if intervals.empty:
+            union[name] = 0
+            continue
+
+        merged = pd.merge_asof(
+            union[["start", "end"]].sort_values("start"),
+            intervals,
+            on="start",
+            direction="backward",
+        )
+        union[name] = merged[name].where(merged["end_y"].ge(union["end"]), 0).fillna(0)
+
+    value_columns = list(bedgraphs.keys())
+    union = union.loc[lambda df: df[value_columns].ne(0).any(axis=1)]
+    return union[["chrom", "start", "end", *value_columns]]
+
+
+def union_bedgraphs(bedgraphs: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+    chromosomes = sorted(
+        {
+            chrom
+            for dataframe in bedgraphs.values()
+            for chrom in dataframe["chrom"].dropna().unique().tolist()
+        }
+    )
+    union = pd.concat(
+        [_segment_union_for_chrom(chrom, bedgraphs) for chrom in chromosomes],
+        ignore_index=True,
+    )
+    return union.sort_values(["chrom", "start", "end"]).reset_index(drop=True)
 
 
 def concat(
@@ -72,10 +137,7 @@ def concat(
                             CoolerBedGraph(
                                 uri, region_to_limit=region if region else None
                             )
-                            .extract_bedgraph(
-                                normalisation=normalisation, **norm_kwargs
-                            )
-                            .pipe(BedTool.from_dataframe),
+                            .extract_bedgraph(normalisation=normalisation, **norm_kwargs),
                         )
                     )(uri)
                     for uri in cooler_uris
@@ -84,18 +146,21 @@ def concat(
 
         elif input_format == "bedgraph":
 
-            bedgraphs = {os.path.basename(fn): BedTool(fn) for fn in infiles}
+            bedgraphs = {
+                os.path.basename(fn): _read_bedgraph(fn, os.path.basename(fn))
+                for fn in infiles
+            }
 
         else:
             raise NotImplementedError("Auto currently not implemented")
 
-        union = (
-            BedTool()
-            .union_bedgraphs(i=[bt.fn for bt in bedgraphs.values()])
-            .to_dataframe(
-                disable_auto_names=True,
-                names=["chrom", "start", "end", *list(bedgraphs.keys())],
-            )
+        union = union_bedgraphs(
+            {
+                name: dataframe.rename(columns={"count": name})
+                if "count" in dataframe.columns
+                else dataframe
+                for name, dataframe in bedgraphs.items()
+            }
         )
 
         if output:

--- a/capcruncher/pipeline/utils.py
+++ b/capcruncher/pipeline/utils.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import json
 import itertools
 import pandas as pd
-import pyranges as pr
+import pyranges1 as pr
 
 from capcruncher import utils
 
@@ -130,7 +130,7 @@ def get_blacklist(config):
 
 
 def has_high_viewpoint_number(viewpoints: str, config: Dict):
-    n_viewpoints = pr.read_bed(viewpoints).df.shape[0]
+    n_viewpoints = len(pd.DataFrame(pr.read_bed(viewpoints)))
     if n_viewpoints > 500:
         if not config["analysis_optional"].get("force_bigwig_generation", False):
             return True

--- a/capcruncher/pipeline/workflow/Snakefile
+++ b/capcruncher/pipeline/workflow/Snakefile
@@ -5,7 +5,7 @@ import shutil
 import json
 
 import pandas as pd
-import pyranges as pr
+import pyranges1 as pr
 import snakemake.utils
 
 import capcruncher.pipeline.utils
@@ -49,7 +49,9 @@ DESIGN.to_csv("capcruncher_output/design.tsv", sep="\t", index=False)
 
 ## Read viewpoints
 VIEWPOINTS = config["analysis"]["viewpoints"]
-VIEWPOINT_NAMES = convert_bed_to_pr(VIEWPOINTS).df.Name.drop_duplicates().tolist()
+VIEWPOINT_NAMES = (
+    pd.DataFrame(convert_bed_to_pr(VIEWPOINTS))["Name"].drop_duplicates().tolist()
+)
 
 ### Check that viewpoints do not contain any special characters
 for viewpoint in VIEWPOINT_NAMES:

--- a/capcruncher/pipeline/workflow/envs/environment.yml
+++ b/capcruncher/pipeline/workflow/envs/environment.yml
@@ -28,7 +28,9 @@ dependencies:
   - ucsc-bedtobigbed
   - ucsc-bedgraphtobigwig
   - homer
-  - pybedtools
+  - pip
+  - pip:
+    - pyranges1
   - snakemake
   - subread
   - star

--- a/capcruncher/pipeline/workflow/rules/annotate.smk
+++ b/capcruncher/pipeline/workflow/rules/annotate.smk
@@ -1,5 +1,5 @@
 import json
-import pyranges as pr
+import pyranges1 as pr
 import capcruncher.pipeline.utils
 
 

--- a/capcruncher/pipeline/workflow/scripts/validation_check_n_bins_per_viewpoint.py
+++ b/capcruncher/pipeline/workflow/scripts/validation_check_n_bins_per_viewpoint.py
@@ -4,7 +4,7 @@ Aim: Check that there is only one restriction fragment per viewpoint.
 
 import pandas as pd
 import numpy as np
-import pyranges as pr
+import pyranges1 as pr
 import polars as pl
 import pathlib
 from loguru import logger
@@ -18,7 +18,7 @@ with logger.catch():
     viewpoints = snakemake.input.viewpoints
     
     gr = BedIntersector(viewpoints, bins, "restriction_fragments", 0.51).get_intersection(method="count")
-    multiple_fragments = (gr.df["restriction_fragments"] > 1).sum()
+    multiple_fragments = (pd.DataFrame(gr)["restriction_fragments"] > 1).sum()
     has_multiple_frags = multiple_fragments > 0
 
 

--- a/capcruncher/pipeline/workflow/scripts/validation_confirm_annotated_viewpoints_present.py
+++ b/capcruncher/pipeline/workflow/scripts/validation_confirm_annotated_viewpoints_present.py
@@ -4,7 +4,7 @@ Aim: Ensure that all viewpoints are found in the annotated slices.
 
 import pandas as pd
 import numpy as np
-import pyranges as pr
+import pyranges1 as pr
 import polars as pl
 import tabulate
 import pathlib
@@ -12,6 +12,7 @@ import pathlib
 slices = snakemake.input.slices
 viewpoints = snakemake.input.viewpoints
 gr_viewpoints = pr.read_bed(viewpoints)
+df_viewpoints = pd.DataFrame(gr_viewpoints)
 
 with pl.StringCache():
     vp_counts = []
@@ -29,9 +30,11 @@ df_counts.rename(columns={"counts": "n_slices"}).to_csv(
 )
 
 
-if not gr_viewpoints.df.Name.isin(df_counts.capture).all():
+if not df_viewpoints["Name"].isin(df_counts.capture).all():
     # check which viewpoints are missing
-    missing = gr_viewpoints.df.Name[~viewpoints.df.Name.isin(df_counts.capture)]
+    missing = df_viewpoints.loc[
+        ~df_viewpoints["Name"].isin(df_counts.capture), "Name"
+    ]
     raise ValueError(f"Not all viewpoints are present in the annotation: {missing}")
 
 else:

--- a/capcruncher/utils.py
+++ b/capcruncher/utils.py
@@ -3,11 +3,26 @@ import os
 import pickle
 import re
 from functools import wraps
-from typing import Callable, Generator, Iterable, Tuple, Type, Union
+from typing import Callable, Iterable, Mapping, Sequence, Tuple, Union
 
 import pandas as pd
-import pybedtools
-import pyranges as pr
+import pyranges1 as pr
+
+
+BED_COLUMN_NAMES = ("chrom", "start", "end", "name", "score", "strand")
+PYRANGES_TO_BED_COLUMNS = {
+    "Chromosome": "chrom",
+    "Start": "start",
+    "End": "end",
+    "Name": "name",
+    "Score": "score",
+    "Strand": "strand",
+}
+BED_TO_PYRANGES_COLUMNS = {value: key for key, value in PYRANGES_TO_BED_COLUMNS.items()}
+
+
+def _pyranges_to_dataframe(gr: pr.PyRanges) -> pd.DataFrame:
+    return pd.DataFrame(gr).copy()
 
 
 def cycle_argument(arg):
@@ -87,20 +102,80 @@ def get_human_readable_number_of_bp(bp: int) -> str:
     return bp
 
 
-def is_valid_bed(bed: Union[str, pybedtools.BedTool], verbose=True) -> bool:
+def _bed_column_names(n_columns: int) -> list[str]:
+    base_columns = list(BED_COLUMN_NAMES[: min(n_columns, len(BED_COLUMN_NAMES))])
+    extra_columns = [f"column_{index}" for index in range(len(base_columns) + 1, n_columns + 1)]
+    return [*base_columns, *extra_columns]
+
+
+def _coerce_bedframe(df: pd.DataFrame) -> pd.DataFrame:
+    bed = df.copy()
+
+    if all(isinstance(column, int) for column in bed.columns):
+        bed.columns = _bed_column_names(bed.shape[1])
+    else:
+        bed = bed.rename(columns=PYRANGES_TO_BED_COLUMNS)
+
+    required_columns = [column for column in BED_COLUMN_NAMES[:3] if column in bed.columns]
+    if len(required_columns) < 3:
+        raise IndexError("Wrong number of fields detected check separator or number of columns")
+
+    bed["start"] = pd.to_numeric(bed["start"], errors="raise").astype(int)
+    bed["end"] = pd.to_numeric(bed["end"], errors="raise").astype(int)
+
+    return bed
+
+
+def _read_bed_file(path: Union[str, os.PathLike]) -> pd.DataFrame:
+    bed = pd.read_csv(path, sep="\t", header=None, comment="#")
+    if bed.empty:
+        raise pd.errors.EmptyDataError(f"{path} is empty")
+
+    bed.columns = _bed_column_names(bed.shape[1])
+    return _coerce_bedframe(bed)
+
+
+def _ensure_name_column(df: pd.DataFrame, prefix: str = "region") -> pd.DataFrame:
+    bed = df.copy()
+    if "name" not in bed.columns:
+        bed["name"] = [f"{prefix}_{index}" for index in range(len(bed))]
+    else:
+        missing_names = bed["name"].isna() | (bed["name"].astype(str).str.len() == 0)
+        if missing_names.any():
+            bed.loc[missing_names, "name"] = [
+                f"{prefix}_{index}" for index in bed.index[missing_names]
+            ]
+
+    return bed
+
+
+def _parse_region(region: Union[str, Sequence[Union[str, int]]]) -> tuple[str, int, int]:
+    if isinstance(region, str):
+        chrom, coordinates = region.split(":", maxsplit=1)
+        start, end = coordinates.split("-", maxsplit=1)
+        return chrom, int(start), int(end)
+
+    chrom, start, end = region[:3]
+    return str(chrom), int(start), int(end)
+
+
+def is_valid_bed(bed: Union[str, os.PathLike, pd.DataFrame, pr.PyRanges], verbose=True) -> bool:
     from loguru import logger
 
     """Returns true if bed file can be opened and has at least 3 columns"""
     try:
-        bed = pybedtools.BedTool(bed)
-        if bed.field_count(n=1) >= 3:
+        bed = convert_bed_to_dataframe(bed)
+        if {"chrom", "start", "end"}.issubset(bed.columns):
             return True
 
     except Exception as e:
+        if not verbose:
+            return False
+
         if isinstance(e, FileNotFoundError):
             logger.warning(f"Bed file: {bed} not found")
 
-        elif isinstance(e, IndexError):
+        elif isinstance(e, (IndexError, ValueError, pd.errors.ParserError)):
             logger.warning(
                 "Wrong number of fields detected check separator or number of columns"
             )
@@ -108,24 +183,19 @@ def is_valid_bed(bed: Union[str, pybedtools.BedTool], verbose=True) -> bool:
         else:
             logger.warning(f"Exception raised {e}")
 
+    return False
 
-def bed_has_name(bed: Union[str, pybedtools.BedTool]) -> bool:
+
+def bed_has_name(bed: Union[str, os.PathLike, pd.DataFrame, pr.PyRanges]) -> bool:
     """Returns true if bed file has at least 4 columns"""
-    if isinstance(bed, str):
-        bed = pybedtools.BedTool(bed)
-
-    if bed.field_count(n=1) >= 4:
-        return True
+    bed_df = convert_bed_to_dataframe(bed)
+    return "name" in bed_df.columns
 
 
-def bed_has_duplicate_names(bed: Union[str, pybedtools.BedTool]) -> bool:
-    """Returns true if bed file has no duplicated names"""
-    if isinstance(bed, str):
-        bed = pybedtools.BedTool(bed)
-
-    df = bed.to_dataframe()
-    if not df["name"].duplicated().shape[0] > 1:
-        return True
+def bed_has_duplicate_names(bed: Union[str, os.PathLike, pd.DataFrame, pr.PyRanges]) -> bool:
+    """Returns true if the bed file contains duplicated names."""
+    bed_df = convert_bed_to_dataframe(bed)
+    return "name" in bed_df.columns and bed_df["name"].duplicated().any()
 
 
 def hash_column(col: Iterable, hash_type=64) -> list:
@@ -148,7 +218,7 @@ def hash_column(col: Iterable, hash_type=64) -> list:
 
 
 def split_intervals_on_chrom(
-    intervals: Union[str, pybedtools.BedTool, pd.DataFrame]
+    intervals: Union[str, os.PathLike, pd.DataFrame, pr.PyRanges]
 ) -> dict:
     """Creates dictionary from bed file with the chroms as keys"""
 
@@ -159,20 +229,45 @@ def split_intervals_on_chrom(
 def intersect_bins(
     bins_1: pd.DataFrame, bins_2: pd.DataFrame, **bedtools_kwargs
 ) -> pd.DataFrame:
-    """Intersects two sets of genomic intervals using pybedtools.BedTools intersect.
+    """Intersects two sets of genomic intervals using PyRanges joins."""
 
-    Formats the intersection in a clearer way than pybedtool auto names.
+    _ = bedtools_kwargs
 
-    """
+    pr_1 = convert_bed_to_pr(_ensure_name_column(bins_1))
+    pr_2 = convert_bed_to_pr(_ensure_name_column(bins_2))
+    df_intersect = _pyranges_to_dataframe(
+        pr_1.join_overlaps(pr_2, report_overlap_column="Overlap")
+    )
 
-    bt1 = pybedtools.BedTool.from_dataframe(bins_1)
-    bt2 = pybedtools.BedTool.from_dataframe(bins_2)
-    bt_intersect = bt1.intersect(bt2, **bedtools_kwargs)
-    df_intersect = bt_intersect.to_dataframe(
-        disable_auto_names=True,
-        header=None,
-        index_col=False,
-        names=[
+    if df_intersect.empty:
+        return pd.DataFrame(
+            columns=[
+                "chrom_1",
+                "start_1",
+                "end_1",
+                "name_1",
+                "chrom_2",
+                "start_2",
+                "end_2",
+                "name_2",
+                "overlap",
+            ]
+        )
+
+    return df_intersect.rename(
+        columns={
+            "Chromosome": "chrom_1",
+            "Start": "start_1",
+            "End": "end_1",
+            "Name": "name_1",
+            "Chromosome_b": "chrom_2",
+            "Start_b": "start_2",
+            "End_b": "end_2",
+            "Name_b": "name_2",
+            "Overlap": "overlap",
+        }
+    )[
+        [
             "chrom_1",
             "start_1",
             "end_1",
@@ -182,10 +277,8 @@ def intersect_bins(
             "end_2",
             "name_2",
             "overlap",
-        ],
-    )
-
-    return df_intersect
+        ]
+    ]
 
 
 def load_dict(fn, format: str, dtype: str = "int") -> dict:
@@ -262,17 +355,10 @@ def get_timing(task_name=None) -> Callable:
 
 
 def convert_to_bedtool(
-    bed: Union[str, pybedtools.BedTool, pd.DataFrame]
-) -> pybedtools.BedTool:
-    """Converts a str or pd.DataFrame to a pybedtools.BedTool object"""
-    if isinstance(bed, str):
-        bed_conv = pybedtools.BedTool(bed)
-    elif isinstance(bed, pd.DataFrame):
-        bed_conv = pybedtools.BedTool.from_dataframe(bed)
-    elif isinstance(bed, pybedtools.BedTool):
-        bed_conv = bed
-
-    return bed_conv
+    bed: Union[str, os.PathLike, pd.DataFrame, pr.PyRanges]
+) -> pd.DataFrame:
+    """Returns a dataframe representation of a bed-like object."""
+    return convert_bed_to_dataframe(bed)
 
 
 def categorise_tracks(ser: pd.Series) -> list:
@@ -303,7 +389,7 @@ def categorise_tracks(ser: pd.Series) -> list:
 def convert_bed_to_pr(
     bed: Union[
         str,
-        pybedtools.BedTool,
+        os.PathLike,
         pd.DataFrame,
         pr.PyRanges,
     ],
@@ -315,64 +401,31 @@ def convert_bed_to_pr(
         pr.PyRanges: PyRanges object.
     """
 
-    import polars as pl
+    if isinstance(bed, pr.PyRanges):
+        converted = bed
 
-    if isinstance(bed, str):
+    else:
         try:
-            df = pl.read_csv(
-                bed,
-                separator="\t",
-                new_columns=["Chromosome", "Start", "End", "Name"],
-                has_header=False,
-                dtypes=[pl.Utf8, pl.Int64, pl.Int64, pl.Utf8],
-                columns=list(range(4)),
-            )
-
-            converted = (
-                df.to_pandas()
-                .assign(Name=lambda df: df.Name.astype('category'))
-                .pipe(pr.PyRanges)
-            )
-
-        except (FileNotFoundError, pl.exceptions.NoDataError):
+            bed_df = convert_bed_to_dataframe(bed)
+        except (FileNotFoundError, pd.errors.EmptyDataError):
             from loguru import logger
 
             logger.warning(f"File {bed} not found")
-            converted = pr.PyRanges()
+            return pr.PyRanges()
 
-    elif isinstance(bed, pybedtools.BedTool):
         converted = (
-            bed.to_dataframe()
-            .rename(
-                columns={
-                    "chrom": "Chromosome",
-                    "start": "Start",
-                    "end": "End",
-                    "name": "Name",
-                }
-            )
+            _ensure_name_column(bed_df)
+            .rename(columns=BED_TO_PYRANGES_COLUMNS)
+            .assign(Name=lambda df: df["Name"].astype("category"))
             .pipe(pr.PyRanges)
         )
-
-    elif isinstance(bed, pr.PyRanges):
-        converted = bed
-
-    elif isinstance(bed, pd.DataFrame):
-        converted = bed.rename(
-            columns={
-                "chrom": "Chromosome",
-                "start": "Start",
-                "end": "End",
-                "name": "Name",
-            }
-        ).pipe(pr.PyRanges)
 
     return converted
 
 
 def convert_bed_to_dataframe(
     bed: Union[
-        str, pybedtools.BedTool, pd.DataFrame, pr.PyRanges
+        str, os.PathLike, pd.DataFrame, pr.PyRanges
     ],  # noqa: F821
     ignore_ray_objrefs=False,
 ) -> pd.DataFrame:
@@ -380,17 +433,14 @@ def convert_bed_to_dataframe(
     import ray
     from loguru import logger
 
-    if isinstance(bed, str):
-        bed_conv = pybedtools.BedTool(bed).to_dataframe()
-
-    elif isinstance(bed, pybedtools.BedTool):
-        bed_conv = bed.to_dataframe()
+    if isinstance(bed, (str, os.PathLike)):
+        bed_conv = _read_bed_file(bed)
 
     elif isinstance(bed, pd.DataFrame):
-        bed_conv = bed
+        bed_conv = _coerce_bedframe(bed)
 
     elif isinstance(bed, pr.PyRanges):
-        bed_conv = bed.as_df()
+        bed_conv = _coerce_bedframe(_pyranges_to_dataframe(bed))
 
     elif isinstance(bed, ray.ObjectRef):
         if ignore_ray_objrefs:
@@ -401,6 +451,29 @@ def convert_bed_to_dataframe(
             bed_conv = convert_bed_to_dataframe(bed)
 
     return bed_conv
+
+
+def bam_to_bed_dataframe(bam: Union[str, os.PathLike]) -> pd.DataFrame:
+    import pysam
+
+    rows = []
+    with pysam.AlignmentFile(bam, "rb") as alignment_file:
+        for alignment in alignment_file.fetch(until_eof=True):
+            if alignment.is_unmapped:
+                continue
+
+            rows.append(
+                {
+                    "chrom": alignment.reference_name,
+                    "start": alignment.reference_start,
+                    "end": alignment.reference_end,
+                    "name": alignment.query_name,
+                    "score": alignment.mapping_quality,
+                    "strand": "-" if alignment.is_reverse else "+",
+                }
+            )
+
+    return pd.DataFrame(rows, columns=list(BED_COLUMN_NAMES))
 
 
 def is_tabix(file: str):
@@ -420,8 +493,34 @@ def is_tabix(file: str):
     return _is_tabix
 
 
-def format_coordinates(coordinates: Union[str, os.PathLike]) -> pybedtools.BedTool:
-    """Converts coordinates supplied in string format or a .bed file to a BedTool.
+def fetch_bed_intervals(
+    bed: Union[str, os.PathLike],
+    region: Union[str, Sequence[Union[str, int]]],
+) -> pd.DataFrame:
+    import pysam
+
+    chrom, start, end = _parse_region(region)
+
+    if is_tabix(bed):
+        with pysam.TabixFile(bed) as tabix_file:
+            rows = list(tabix_file.fetch(chrom, start, end, parser=pysam.asTuple()))
+
+        if not rows:
+            return pd.DataFrame(columns=list(BED_COLUMN_NAMES[:4]))
+
+        fetched = pd.DataFrame(rows, columns=_bed_column_names(len(rows[0])))
+        fetched = _coerce_bedframe(fetched)
+    else:
+        fetched = convert_bed_to_dataframe(bed)
+        fetched = fetched.loc[
+            lambda df: (df["chrom"] == chrom) & (df["start"] < end) & (df["end"] > start)
+        ]
+
+    return fetched.reset_index(drop=True)
+
+
+def format_coordinates(coordinates: Union[str, os.PathLike]) -> pd.DataFrame:
+    """Converts coordinates supplied in string format or a .bed file to a dataframe.
 
     Args:
         coordinates (Union[str, os.PathLike]): Coordinates in the form chr:start-end/path.
@@ -429,7 +528,7 @@ def format_coordinates(coordinates: Union[str, os.PathLike]) -> pybedtools.BedTo
         ValueError: Inputs must be supplied in the correct format.
 
     Returns:
-        BedTool: BedTool object containing the required coordinates.
+        pd.DataFrame: DataFrame containing the required coordinates.
     """
 
     coordinates = str(coordinates)
@@ -441,22 +540,16 @@ def format_coordinates(coordinates: Union[str, os.PathLike]) -> pybedtools.BedTo
         if len(coordinates_split) < 4:
             coordinates_split.append("region_0")
 
-        bt = pybedtools.BedTool(" ".join(coordinates_split), from_string=True)
+        bed = pd.DataFrame(
+            [coordinates_split], columns=["chrom", "start", "end", "name"]
+        ).assign(start=lambda df: df["start"].astype(int), end=lambda df: df["end"].astype(int))
 
     elif pattern_bed_file.match(coordinates):
         if is_valid_bed(coordinates):
-            if bed_has_name(coordinates):
-                bt = pybedtools.BedTool(coordinates)
-            else:
-                bt = (
-                    pybedtools.BedTool(coordinates)
-                    .to_dataframe()
-                    .reset_index()
-                    .assign(name=lambda df: "region_" + df["index"].astype("string"))[
-                        ["chrom", "start", "end", "name"]
-                    ]
-                    .pipe(pybedtools.BedTool.from_dataframe)
-                )
+            bed = convert_bed_to_dataframe(coordinates)
+            bed = _ensure_name_column(bed.reset_index(drop=True))[
+                ["chrom", "start", "end", "name"]
+            ]
         else:
             raise ValueError("Invalid bed file supplied.")
 
@@ -465,31 +558,39 @@ def format_coordinates(coordinates: Union[str, os.PathLike]) -> pybedtools.BedTo
             """Provide coordinates in the form chr[NUMBER]:[START]-[END]/BED file"""
         )
 
-    return bt
+    return bed
 
 
 def convert_interval_to_coords(
-    interval: Union[pybedtools.Interval, dict], named=False
+    interval: Union[Mapping, pd.Series], named=False
 ) -> Tuple[str]:
     """Converts interval object to standard genomic coordinates.
 
     e.g. chr1:1000-2000
 
     Args:
-        interval (Union[pybedtools.Interval, dict]): Interval to convert.
+        interval (Union[Mapping, pd.Series]): Interval to convert.
 
     Returns:
         Tuple: Genomic coordinates in the format chr:start-end
     """
+    if hasattr(interval, "_asdict"):
+        interval = interval._asdict()
+
+    chrom = interval.get("chrom", interval.get("Chromosome"))
+    start = interval.get("start", interval.get("Start"))
+    end = interval.get("end", interval.get("End"))
+    name = interval.get("name", interval.get("Name", "Unnammed"))
+
     if not named:
         return (
             "Unnammed",
-            f'{interval["chrom"]}:{interval["start"]}-{interval["end"]}',
+            f"{chrom}:{start}-{end}",
         )
     else:
         return (
-            interval["name"],
-            f'{interval["chrom"]}:{interval["start"]}-{interval["end"]}',
+            name,
+            f"{chrom}:{start}-{end}",
         )
 
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,7 +8,6 @@ pandas<=2.1.2
 polars<=1.6.0
 PuLP<2.8.0
 pyarrow
-pybedtools
-pyranges<=0.1.2
+pyranges1
 snakemake_wrapper_utils
 snakemake<=7.32.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ more-itertools
 numpy<=1.26.4
 pandas<=2.1.2
 PuLP<2.8.0
-pyranges<=0.1.2
+pyranges1
 snakemake_wrapper_utils
 snakemake<=7.32.4
 
@@ -24,7 +24,6 @@ plotly>5.0.0,<=5.18.0
 polars<=1.27.1
 protobuf<=6.30.2
 pyarrow>11.0.0,<19.0.1
-pybedtools<=0.9.1
 pydantic>2.4.0,<2.11.0
 pydeseq2<=0.5.0
 pysam>0.15.0,<=0.21.0

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,5 +1,6 @@
 import os
 
+import pandas as pd
 import pytest
 from capcruncher.api.annotate import BedIntersector
 
@@ -63,7 +64,7 @@ def test_bed_intersection_succeeds(
 
     intersection = bi.get_intersection(method=method)
     assert name in intersection.columns
-    assert intersection.df.shape[0] == n_rows_expected
+    assert pd.DataFrame(intersection).shape[0] == n_rows_expected
 
 
 def test_bed_intersection_get_output(data_path):
@@ -79,7 +80,7 @@ def test_bed_intersection_get_output(data_path):
 
     intersection = bi.get_intersection(method="get")
     assert "capture" in intersection.columns
-    assert intersection.df["capture"].value_counts().loc["CAPTURE"] == 1
+    assert pd.DataFrame(intersection)["capture"].value_counts().loc["CAPTURE"] == 1
 
 
 def test_bed_intersection_count_output(data_path):
@@ -95,7 +96,7 @@ def test_bed_intersection_count_output(data_path):
 
     intersection = bi.get_intersection(method="count")
     assert "capture" in intersection.columns
-    assert intersection.df["capture"].sum() == 1
+    assert pd.DataFrame(intersection)["capture"].sum() == 1
 
 def test_multi_intersection(data_path):
     

--- a/tests/test_pileup.py
+++ b/tests/test_pileup.py
@@ -1,7 +1,7 @@
 import pathlib
 
 import pandas as pd
-import pyranges as pr
+import pyranges1 as pr
 import pytest
 
 from capcruncher.api.pileup import CoolerBedGraph


### PR DESCRIPTION
## Summary
- replace legacy pybedtools and old pyranges interval operations with PyRanges1-native helpers
- update downstream annotation, pileup, utilities, and workflow call sites to PyRanges1 dataframe semantics
- remove pybedtools from dependency manifests and swap runtime requirements to pyranges1

## Testing
- .venv/bin/python -m pytest tests/test_annotate.py tests/test_utils.py tests/test_pileup.py tests/test_cli.py -k "make_chicago_maps or reporters_pileup" -q
- .venv/bin/python -m pytest tests/test_cli.py -k "reporters_pileup and bigWig" -q