### PR TITLE
PR 03: Modernize dataframe and query layer

### DIFF
--- a/capcruncher/cli/cli_utilities.py
+++ b/capcruncher/cli/cli_utilities.py
@@ -4,13 +4,17 @@ from tempfile import NamedTemporaryFile
 from typing import Iterable, List, Literal
 
 import click
-import ibis
+import duckdb
 import pandas as pd
-from ibis import _
 from loguru import logger
 
 from capcruncher.api.statistics import CisOrTransStats
 from capcruncher.utils import bam_to_bed_dataframe, convert_bed_to_pr, get_file_type
+
+
+def parquet_source(path: str):
+    parquet_path = f"{path}/*.parquet" if os.path.isdir(path) else str(path)
+    return parquet_path.replace("'", "''")
 
 
 @click.group()
@@ -78,72 +82,93 @@ def cis_and_trans_stats(
     sample_name: str,
     assay: Literal["capture", "tri", "tiled"] = "capture",
 ):
-    con = ibis.duckdb.connect()
-
-    if not os.path.isdir(slices):
-        tbl = con.register(f"parquet://{slices}", table_name="slices_tbl")
-    else:
-        tbl = con.register(f"parquet://{slices}/*.parquet", table_name="slices_tbl")
-
-    tbl = tbl.mutate(capture=tbl["capture"].fillna("reporter")).select(
-        ["capture", "parent_id", "chrom", "viewpoint", "pe"]
-    )
+    con = duckdb.connect()
+    slices_path = parquet_source(slices)
 
     if assay in ["capture", "tri"]:
-        tbl_reporter = tbl[(tbl["capture"] == "reporter")].drop(
-            "viewpoint", "pe", "capture"
-        )
-
-        tbl_capture = tbl[~(tbl["capture"] == "reporter")]
-
-        tbl_merge = tbl_capture.join(
-            tbl_reporter,
-            predicates=[
-                "parent_id",
-            ],
-            lname="{name}_capture",
-            rname="{name}_reporter",
-            how="left",
-        )
-
-        tbl_merge = tbl_merge.mutate(
-            is_cis=(tbl_merge["chrom_capture"] == tbl_merge["chrom_reporter"])
-        )
-
-        df_cis_and_trans = (
-            tbl_merge.group_by(["viewpoint", "is_cis", "pe"])
-            .aggregate(
-                count=_.count(),
+        df_cis_and_trans = con.sql(
+            f"""
+            WITH tbl AS (
+                SELECT
+                    coalesce(capture, 'reporter') AS capture,
+                    parent_id,
+                    chrom,
+                    viewpoint,
+                    pe
+                FROM read_parquet('{slices_path}')
+            ),
+            tbl_reporter AS (
+                SELECT parent_id, chrom AS chrom_reporter
+                FROM tbl
+                WHERE capture = 'reporter'
+            ),
+            tbl_capture AS (
+                SELECT viewpoint, pe, parent_id, chrom AS chrom_capture
+                FROM tbl
+                WHERE capture != 'reporter'
             )
-            .execute(limit=None)
-        )
+            SELECT
+                viewpoint,
+                chrom_capture = chrom_reporter AS is_cis,
+                pe,
+                count(*) AS count
+            FROM tbl_capture
+            LEFT JOIN tbl_reporter USING (parent_id)
+            GROUP BY viewpoint, is_cis, pe
+            """
+        ).df()
 
     else:
-        viewpoint_chroms = (
-            tbl.filter(tbl["capture"] != "reporter")
-            .group_by(["viewpoint", "chrom"])
-            .aggregate(chrom_count=_.count())
-            .order_by(ibis.desc("chrom_count"))
-            .to_pandas()
-            .drop_duplicates("viewpoint")
-            .set_index("viewpoint")
-            .to_dict()["chrom"]
-        )
-
-        chrom_mapping_exp = ibis.case()
-        for k, v in viewpoint_chroms.items():
-            chrom_mapping_exp = chrom_mapping_exp.when(tbl.viewpoint == k, v)
-        chrom_mapping_exp = chrom_mapping_exp.end()
-
-        df_cis_and_trans = (
-            tbl.mutate(cis_chrom=chrom_mapping_exp)
-            .mutate(is_cis=_.chrom == _.cis_chrom)
-            .group_by(["viewpoint", "parent_id", "is_cis", "pe"])
-            .aggregate(count=_.count())
-            .group_by(["viewpoint", "is_cis", "pe"])
-            .aggregate(count=_["count"].sum())
-            .execute(limit=None)
-        )
+        df_cis_and_trans = con.sql(
+            f"""
+            WITH tbl AS (
+                SELECT
+                    coalesce(capture, 'reporter') AS capture,
+                    parent_id,
+                    chrom,
+                    viewpoint,
+                    pe
+                FROM read_parquet('{slices_path}')
+            ),
+            viewpoint_chroms AS (
+                SELECT
+                    viewpoint,
+                    chrom,
+                    row_number() OVER (
+                        PARTITION BY viewpoint
+                        ORDER BY count(*) DESC, chrom
+                    ) AS rn
+                FROM tbl
+                WHERE capture != 'reporter'
+                GROUP BY viewpoint, chrom
+            ),
+            annotated AS (
+                SELECT
+                    t.viewpoint,
+                    t.parent_id,
+                    t.pe,
+                    t.chrom,
+                    vc.chrom AS cis_chrom
+                FROM tbl AS t
+                LEFT JOIN viewpoint_chroms AS vc
+                    ON t.viewpoint = vc.viewpoint
+                   AND vc.rn = 1
+            ),
+            per_parent AS (
+                SELECT
+                    viewpoint,
+                    parent_id,
+                    chrom = cis_chrom AS is_cis,
+                    pe,
+                    count(*) AS count
+                FROM annotated
+                GROUP BY viewpoint, parent_id, is_cis, pe
+            )
+            SELECT viewpoint, is_cis, pe, sum(count) AS count
+            FROM per_parent
+            GROUP BY viewpoint, is_cis, pe
+            """
+        ).df()
 
     df_cis_and_trans = (
         df_cis_and_trans.rename(columns={"pe": "read_type", "is_cis": "cis/trans"})
@@ -284,17 +309,17 @@ def dump_cooler(path: str, viewpoint: str, resolution: int = None) -> pd.DataFra
 
 
 def dump_capcruncher_parquet(path: str, viewpoint: str = None) -> pd.DataFrame:
-    import ibis
-
-    con = ibis.duckdb.connect()
-
+    con = duckdb.connect()
+    parquet_path = parquet_source(path)
     if viewpoint:
-        tbl = con.register(f"parquet://{path}/*.parquet", table_name="slices_tbl")
-        tbl = tbl.filter(tbl.viewpoint == viewpoint)
+        viewpoint = viewpoint.replace("'", "''")
+        query = (
+            f"SELECT * FROM read_parquet('{parquet_path}') WHERE viewpoint = '{viewpoint}'"
+        )
     else:
-        tbl = con.register(f"parquet://{path}", table_name="slices_tbl")
+        query = f"SELECT * FROM read_parquet('{parquet_path}')"
 
-    return tbl.execute(limit=None)
+    return con.sql(query).df()
 
 
 @cli.command()

--- a/capcruncher/cli/genome_digest.py
+++ b/capcruncher/cli/genome_digest.py
@@ -71,15 +71,22 @@ def digest(
     if sort:
         logger.info("Sorting output")
         df = pl.read_csv(
-            output_file, separator="\t", new_columns=["chrom", "start", "end", "name"],
-            dtypes= [pl.Utf8, pl.Int64, pl.Int64, pl.Utf8]
+            output_file,
+            separator="\t",
+            new_columns=["chrom", "start", "end", "name"],
+            schema_overrides={
+                "chrom": pl.Utf8,
+                "start": pl.Int64,
+                "end": pl.Int64,
+                "name": pl.Utf8,
+            },
         )
 
         # If changing the order, also need to change the fragment number
         df = (
             df.sort(["chrom", "start"])
             .drop(["name"])
-            .with_row_count("name")[["chrom", "start", "end", "name"]]
+            .with_row_index("name")[["chrom", "start", "end", "name"]]
         )
 
         df.write_csv(output_file, separator="\t", include_header=False)

--- a/capcruncher/cli/interactions_deduplicate.py
+++ b/capcruncher/cli/interactions_deduplicate.py
@@ -1,13 +1,16 @@
 import os
-import ibis
-from ibis import _
-import pyarrow.dataset as ds
 import shutil
+
+import duckdb
+import pyarrow.dataset as ds
 from loguru import logger
 
 from capcruncher.api.statistics import AlignmentDeduplicationStats
 
-ibis.options.interactive = False
+
+def parquet_source(path: os.PathLike) -> str:
+    parquet_path = f"{path}/*.parquet" if os.path.isdir(path) else str(path)
+    return parquet_path.replace("'", "''")
 
 
 def deduplicate(
@@ -18,49 +21,68 @@ def deduplicate(
     statistics: os.PathLike = "deduplication_stats.json",
 ):
     logger.info("Connecting to DuckDB")
-    con = ibis.duckdb.connect()
+    con = duckdb.connect()
+    slices_source = parquet_source(slices)
 
-    if not os.path.isdir(slices):
-        slices_tbl_raw = con.register(f"parquet://{slices}", table_name="slices_tbl")
-    else:
-        slices_tbl_raw = con.register(
-            f"parquet://{slices}/*.parquet", table_name="slices_tbl"
-        )
-    
-    n_slices_raw = slices_tbl_raw[['slice_id']].distinct().count().execute(limit=None)    
-    n_reads_raw = slices_tbl_raw[["parent_id"]].distinct().count().execute(limit=None)
+    n_slices_raw = con.sql(
+        f"SELECT COUNT(DISTINCT slice_id) AS n_slices FROM read_parquet('{slices_source}')"
+    ).fetchone()[0]
+    n_reads_raw = con.sql(
+        f"SELECT COUNT(DISTINCT parent_id) AS n_reads FROM read_parquet('{slices_source}')"
+    ).fetchone()[0]
 
     if read_type == "pe":
         logger.info("Read type is PE")
         logger.info("Identifying unique fragment IDs")
-        query = (
-            slices_tbl_raw[["chrom", "start", "end", "parent_id"]]
-            .order_by(["chrom", "start", "end", "parent_id"])
-            .group_by(by="parent_id", order_by=["chrom", "start", "end"])
-            .order_by(["chrom", "start", "end", "parent_id"])
-            .mutate(
-                slice_f_chrom=_.chrom.first(),
-                slice_f_start=_.start.first(),
-                slice_l_end=_.end.last(),
+        parent_ids_unique = con.sql(
+            f"""
+            WITH ranked AS (
+                SELECT
+                    chrom,
+                    start,
+                    "end",
+                    parent_id,
+                    row_number() OVER (
+                        PARTITION BY parent_id
+                        ORDER BY chrom, start, "end", parent_id
+                    ) AS rn_first,
+                    row_number() OVER (
+                        PARTITION BY parent_id
+                        ORDER BY chrom DESC, start DESC, "end" DESC, parent_id DESC
+                    ) AS rn_last
+                FROM read_parquet('{slices_source}')
+            ),
+            parent_ranges AS (
+                SELECT
+                    parent_id,
+                    max(CASE WHEN rn_first = 1 THEN chrom END) AS slice_f_chrom,
+                    max(CASE WHEN rn_first = 1 THEN start END) AS slice_f_start,
+                    max(CASE WHEN rn_last = 1 THEN "end" END) AS slice_l_end
+                FROM ranked
+                GROUP BY parent_id
             )
-            .group_by(["slice_f_chrom", "slice_f_start", "slice_l_end"])
-            .mutate(pid=_.parent_id.first())[["pid"]]
-            .distinct()["pid"]
-        )
+            SELECT min(parent_id) AS parent_id_unique
+            FROM parent_ranges
+            GROUP BY slice_f_chrom, slice_f_start, slice_l_end
+            """
+        ).df()["parent_id_unique"].to_numpy()
     elif read_type == "flashed":
         logger.info("Read type is Flashed")
         logger.info("Identifying unique fragment IDs")
-
-        query = (
-            slices_tbl_raw[["coordinates", "parent_id"]]
-            .group_by(by="parent_id", order_by=["coordinates"])
-            .aggregate(coordinates=lambda t: t.coordinates.group_concat(","))
-            .group_by("coordinates")
-            .mutate(parent_id_unique=_.parent_id.first())[["parent_id_unique"]]
-            .distinct()["parent_id_unique"]
-        )
-
-    parent_ids_unique = query.execute(limit=None)
+        parent_ids_unique = con.sql(
+            f"""
+            WITH parent_coordinates AS (
+                SELECT
+                    parent_id,
+                    string_agg(coordinates, ',' ORDER BY coordinates) AS coordinates
+                FROM read_parquet('{slices_source}')
+                GROUP BY parent_id
+            )
+            SELECT min(parent_id) AS parent_id_unique
+            FROM parent_coordinates
+            GROUP BY coordinates
+            """
+        ).df()["parent_id_unique"].to_numpy()
 
     logger.info("Writing deduplicated slices to disk")
     slices_unfiltered_ds = ds.dataset(slices, format="parquet")
@@ -92,8 +114,10 @@ def deduplicate(
     n_reads_unique = parent_ids_unique.shape[0]
     
     # Calculate the number of slices in the output
-    tbl_dedup = con.register(f"parquet://{output}/*.parquet", table_name="dedup_tbl")
-    n_slices_unique = tbl_dedup[['slice_id']].distinct().count().execute(limit=None)
+    output_source = parquet_source(output)
+    n_slices_unique = con.sql(
+        f"SELECT COUNT(DISTINCT slice_id) AS n_slices FROM read_parquet('{output_source}')"
+    ).fetchone()[0]
     
 
     stats = AlignmentDeduplicationStats(

--- a/capcruncher/pipeline/workflow/scripts/count_identified_viewpoints.py
+++ b/capcruncher/pipeline/workflow/scripts/count_identified_viewpoints.py
@@ -1,23 +1,24 @@
 import os
 import sys
+import duckdb
 import pandas as pd
 import numpy as np
 import subprocess
 
 from capcruncher import api
-import ibis
 
 
-ibis.options.interactive = False
-
-con = ibis.duckdb.connect(threads=snakemake.threads)
-tbl = con.register(f"parquet://{snakemake.params.slices_dir}", table_name="reporters")
-unique_viewpoints = (tbl[["viewpoint", "pe"]]
-                        .distinct()
-                        .execute(limit=None)
-                        .replace("", pd.NA)
-                        .dropna()
-)
+con = duckdb.connect()
+con.execute(f"PRAGMA threads={int(snakemake.threads)}")
+parquet_path = str(snakemake.params.slices_dir).replace("'", "''")
+unique_viewpoints = con.sql(
+        f"""
+        SELECT DISTINCT viewpoint, pe
+        FROM read_parquet('{parquet_path}')
+        WHERE nullif(viewpoint, '') IS NOT NULL
+            AND nullif(pe, '') IS NOT NULL
+        """
+).df()
 
 unique_viewpoints.to_csv(snakemake.output[0], sep="\t", index=False)
 


### PR DESCRIPTION
## Summary
- replace deprecated Polars row-index and schema arguments in genome digestion sorting
- remove deprecated pandas categorical dtype helper usage in annotation dtype inference
- replace active ibis query paths with direct DuckDB queries for deduplication and parquet-backed utility/script entry points

## Testing
- .venv/bin/python -m pytest tests/test_digest.py tests/test_cli.py -k "genome_digest or annotate or interactions_deduplicate" -q